### PR TITLE
Fix broken unit/acceptance tests and enforce CI test execution on pull requests

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -43,3 +43,38 @@ jobs:
         uses: CatChen/check-git-status-action@v1
         with:
           fail-if-not-clean: true
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '^1.24'
+          cache: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "^1.13.2"
+          terraform_wrapper: false
+
+      - name: Run Unit Tests
+        run: |
+          make test.unit
+
+      - name: Run Acceptance Tests
+        env:
+          QDRANT_CLOUD_API_KEY: ${{ secrets.QDRANT_CLOUD_API_KEY }}
+          QDRANT_CLOUD_ACCOUNT_ID: ${{ secrets.QDRANT_CLOUD_ACCOUNT_ID }}
+          QDRANT_CLOUD_API_URL: ${{ vars.QDRANT_CLOUD_API_URL }}
+          SKIPPED_TESTS: ${{ vars.SKIPPED_TESTS }}
+        run: |
+          make test.acceptance

--- a/README.md
+++ b/README.md
@@ -68,10 +68,32 @@ provider_installation {
 
 In order to test the provider, you can run `make test`.
 
-This will run the unit tests in the provider.
+This will run the unit & acceptance tests in the provider.
 
 ```bash
-$ QDRANT_CLOUD_API_KEY="<api_key>" QDRANT_CLOUD_ACCOUNT_ID="<account_id>" QDRANT_CLOUD_API_URL="<api_url>" make test
+make test \
+  QDRANT_CLOUD_API_KEY="<API_KEY>" \
+  QDRANT_CLOUD_ACCOUNT_ID="<ACCOUNT_ID>" \
+  QDRANT_CLOUD_API_URL="grpc.development-cloud.qdrant.io" \
+  SKIPPED_TESTS="TestAccDataAccountsBackupSchedule TestAccResourceClusterCreate"
+```
+
+run only unit tests
+
+```bash
+
+make test.unit
+```
+
+run only acceptance tests
+
+```bash
+
+make test.acceptance \
+  QDRANT_CLOUD_API_KEY="<API_KEY>" \
+  QDRANT_CLOUD_ACCOUNT_ID="<ACCOUNT_ID>" \
+  QDRANT_CLOUD_API_URL="grpc.development-cloud.qdrant.io" \
+  SKIPPED_TESTS="TestAccDataAccountsBackupSchedule TestAccResourceClusterCreate"
 ```
 
 or run a single test /wo make (not acceptance and not extra env vars are required);

--- a/docs/data-sources/accounts_backup_schedule.md
+++ b/docs/data-sources/accounts_backup_schedule.md
@@ -17,6 +17,7 @@ Backup Schedule Data Source
 
 ### Required
 
+- `cluster_id` (String) Backup Schedule Schema Cluster ID field
 - `id` (String) Backup Schedule Schema ID field
 
 ### Optional
@@ -26,7 +27,6 @@ Backup Schedule Data Source
 ### Read-Only
 
 - `account_id` (String) Backup Schedule Schema Account ID field
-- `cluster_id` (String) Backup Schedule Schema Cluster ID field
 - `created_at` (String) Backup Schedule Schema Creation time field
 - `cron_expression` (String) Backup Schedule Schema Cron expression for the schedule field
 - `deleted_at` (String) Backup Schedule Schema Deletion time field

--- a/qdrant/data_source_accounts_auth_keys_v2_test.go
+++ b/qdrant/data_source_accounts_auth_keys_v2_test.go
@@ -9,39 +9,67 @@ import (
 )
 
 func TestAccDataAccountsAuthKeysV2(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region = "us-east4"
+	cloud_provider = "%s"
+	cloud_region = "%s"
 }
 locals {
   account_id = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name = "tf-acc-test-cluster-ds-auth-v2"
 	account_id = local.account_id
-	cloud_region = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
+		database_configuration {
+		  service { jwt_rbac = true }
+		}
+
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
@@ -58,7 +86,7 @@ data "qdrant-cloud_accounts_database_api_keys_v2" "test" {
 	cluster_id = qdrant-cloud_accounts_cluster.test.id
 	depends_on = [qdrant-cloud_accounts_database_api_key_v2.test]
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrPair(

--- a/qdrant/data_source_accounts_backup_schedule.go
+++ b/qdrant/data_source_accounts_backup_schedule.go
@@ -37,12 +37,14 @@ func dataAccountsBackupScheduleRead(ctx context.Context, d *schema.ResourceData,
 	resp, err := client.GetBackupSchedule(clientCtx, &backupv1.GetBackupScheduleRequest{
 		AccountId:        accountUUID.String(),
 		ClusterId:        d.Get(backupScheduleClusterIDFieldName).(string),
-		BackupScheduleId: d.Id(),
+		BackupScheduleId: d.Get(backupScheduleIDFieldName).(string),
 	}, grpc.Trailer(&trailer))
 	errorPrefix += getRequestID(trailer)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("%s: %w", errorPrefix, err))
 	}
+
+	d.SetId(resp.GetBackupSchedule().GetId())
 
 	flattened := flattenBackupSchedule(resp.GetBackupSchedule())
 	for k, v := range flattened {

--- a/qdrant/data_source_accounts_backup_schedule_test.go
+++ b/qdrant/data_source_accounts_backup_schedule_test.go
@@ -4,44 +4,71 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataAccountsBackupSchedule(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region   = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name           = "tf-acc-test-cluster-backup-ds-single"
 	account_id     = local.account_id
-	cloud_region   = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
@@ -53,10 +80,11 @@ resource "qdrant-cloud_accounts_backup_schedule" "test" {
 }
 
 data "qdrant-cloud_accounts_backup_schedule" "test" {
-	id = qdrant-cloud_accounts_backup_schedule.test.id
+	id         = qdrant-cloud_accounts_backup_schedule.test.id
+	cluster_id = qdrant-cloud_accounts_cluster.test.id
 	depends_on = [qdrant-cloud_accounts_backup_schedule.test]
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrPair(
@@ -69,7 +97,16 @@ data "qdrant-cloud_accounts_backup_schedule" "test" {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
-			{Config: config, Check: check},
+			// Step 1: create cluster + schedule (no checks; allow eventual consistency)
+			{Config: config},
+
+			// Step 2: short wait, then re-apply same config and assert via data source
+			{
+				PreConfig: func() { time.Sleep(60 * time.Second) },
+				Config:    config,
+				Destroy:   true,
+				Check:     check,
+			},
 		},
 	})
 }

--- a/qdrant/data_source_accounts_backup_schedules_test.go
+++ b/qdrant/data_source_accounts_backup_schedules_test.go
@@ -9,59 +9,90 @@ import (
 )
 
 func TestAccDataAccountsBackupSchedules(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region   = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name           = "tf-acc-test-cluster-backup-ds"
 	account_id     = local.account_id
-	cloud_region   = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
 
+# Create at least one schedule so the list data source has something to return
 resource "qdrant-cloud_accounts_backup_schedule" "test" {
-	cluster_id            = qdrant-cloud_accounts_cluster.test.id
-	cron_expression       = "0 12 * * *"
-	retention_period      = "72h"
-	name                  = "tf-acc-test-backup-schedule-ds"
+	cluster_id       = qdrant-cloud_accounts_cluster.test.id
+	cron_expression  = "0 6 1 * *"  # 6am on the 1st of every month
+	retention_period = "120h"       # 5 days
 }
 
 data "qdrant-cloud_accounts_backup_schedules" "test" {
 	cluster_id = qdrant-cloud_accounts_cluster.test.id
 	depends_on = [qdrant-cloud_accounts_backup_schedule.test]
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttrPair("data.qdrant-cloud_accounts_backup_schedules.test", "cluster_id", "qdrant-cloud_accounts_cluster.test", "id"),
+		resource.TestCheckResourceAttrPair(
+			"data.qdrant-cloud_accounts_backup_schedules.test", "cluster_id",
+			"qdrant-cloud_accounts_cluster.test", "id",
+		),
 		resource.TestCheckResourceAttrSet("data.qdrant-cloud_accounts_backup_schedules.test", "schedules.#"),
+		// This assumes at least one schedule exists and index 0 is valid.
+		// If ordering ever changes, switch to a custom check that searches by ID.
 		resource.TestCheckResourceAttrSet("data.qdrant-cloud_accounts_backup_schedules.test", "schedules.0.id"),
 	)
 

--- a/qdrant/data_source_booking_packages_test.go
+++ b/qdrant/data_source_booking_packages_test.go
@@ -10,35 +10,39 @@ import (
 )
 
 func TestAccDataBookingPackages(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+`, apiKey)
 
-	config := provider + `
+	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	  cloud_provider = "gcp"
-	  cloud_region = "europe-west3"
+  cloud_provider = "%s"
+  cloud_region   = "%s"
 }
 
 locals {
   resource_data = data.qdrant-cloud_booking_packages.test.packages
 
-  // Filter out the free tariffs
+  # Filter out the free tariffs
   free_tariffs = [
-    // TODO: Change the resource.name to resource.type when the API is updated
+    # TODO: Change the resource.name to resource.type when the API is updated
     for resource in local.resource_data : resource if resource.name == "free2"
   ]
 
-  // Get the first free tariff
+  # Get the first free tariff
   first_free_tariff = local.free_tariffs[0]
 }
 
 output "first_free_tariff" {
-	  value = local.first_free_tariff.name
+  value = local.first_free_tariff.name
 }
-`
+`, cloudProvider, cloudRegion)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrSet("data.qdrant-cloud_booking_packages.test", "packages.#"),

--- a/qdrant/resource_accounts_auth_key_test.go
+++ b/qdrant/resource_accounts_auth_key_test.go
@@ -10,40 +10,66 @@ import (
 )
 
 func TestAccResourceAccountsAuthKeys(t *testing.T) {
-	provider := fmt.Sprintf(`	  
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
+	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
+
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  // TODO: Change the resource.name to resource.type when the API is updated
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
-	name = "test-cluster"
-	account_id = local.account_id
-	cloud_region = "us-east4"
-	cloud_provider = "gcp"
+	name           = "tf-acc-test-cluster-auth-keys"
+	account_id     = local.account_id
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
@@ -51,7 +77,7 @@ resource "qdrant-cloud_accounts_cluster" "test" {
 resource "qdrant-cloud_accounts_auth_key" "test" {
 	cluster_ids = [qdrant-cloud_accounts_cluster.test.id]
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrSet("qdrant-cloud_accounts_auth_key.test", "cluster_ids.#"),

--- a/qdrant/resource_accounts_auth_key_v2_test.go
+++ b/qdrant/resource_accounts_auth_key_v2_test.go
@@ -9,56 +9,86 @@ import (
 )
 
 func TestAccResourceAccountsAuthKeyV2(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
-	name = "tf-acc-test-cluster-res-auth-v2"
-	account_id = local.account_id
-	cloud_region = "us-east4"
-	cloud_provider = "gcp"
+	name           = "tf-acc-test-cluster-res-auth-v2"
+	account_id     = local.account_id
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
+		database_configuration {
+		  service { jwt_rbac = true }
+		}
+
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
 
 resource "qdrant-cloud_accounts_database_api_key_v2" "test" {
-	name = "tf-acc-test-key-res-v2"
+	name       = "tf-acc-test-key-res-v2"
 	cluster_id = qdrant-cloud_accounts_cluster.test.id
 	global_access_rule {
 		access_type = "GLOBAL_ACCESS_RULE_ACCESS_TYPE_READ_ONLY"
 	}
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("qdrant-cloud_accounts_database_api_key_v2.test", "name", "tf-acc-test-key-res-v2"),
 		resource.TestCheckResourceAttrSet("qdrant-cloud_accounts_database_api_key_v2.test", "id"),
-		resource.TestCheckResourceAttrSet("qdrant-cloud_accounts_database_api_key_v2.test", "token"),
+		resource.TestCheckResourceAttrSet("qdrant-cloud_accounts_database_api_key_v2.test", "key"),
 		resource.TestCheckResourceAttr("qdrant-cloud_accounts_database_api_key_v2.test", "global_access_rule.0.access_type", "GLOBAL_ACCESS_RULE_ACCESS_TYPE_READ_ONLY"),
 		resource.TestCheckResourceAttrPair("qdrant-cloud_accounts_database_api_key_v2.test", "cluster_id", "qdrant-cloud_accounts_cluster.test", "id"),
 	)

--- a/qdrant/resource_accounts_backup_schedule_test.go
+++ b/qdrant/resource_accounts_backup_schedule_test.go
@@ -9,49 +9,75 @@ import (
 )
 
 func TestAccResourceAccountsBackupSchedule(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region   = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name           = "tf-acc-test-cluster-backup-res"
 	account_id     = local.account_id
-	cloud_region   = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
 
 resource "qdrant-cloud_accounts_backup_schedule" "test" {
-	cluster_id            = qdrant-cloud_accounts_cluster.test.id
-	cron_expression       = "0 0 1 * *" // Run at midnight on the 1st of every month
-	retention_period      = "168h"      // 7 days
+	cluster_id       = qdrant-cloud_accounts_cluster.test.id
+	cron_expression  = "0 0 1 * *" # Run at midnight on the 1st of every month
+	retention_period = "168h"      # 7 days
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("qdrant-cloud_accounts_backup_schedule.test", "cron_expression", "0 0 1 * *"),
@@ -68,60 +94,95 @@ resource "qdrant-cloud_accounts_backup_schedule" "test" {
 }
 
 func TestAccResourceAccountsBackupScheduleDeleteWithoutBackups(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "aws")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "eu-central-1")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-	cloud_provider = "gcp"
-	cloud_region   = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
-  account_id = "%s"
+  account_id    = "%s"
   resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter out the free tariffs
-  free_tariffs = [
-    for resource in local.resource_data : resource if resource.name == "free2"
+
+  # Filter only paid tariffs
+  paid_tariffs = [
+    for p in local.resource_data : p if try(p.type, "") == "paid"
   ]
-  // Get the first free tariff
-  first_free_tariff = local.free_tariffs[0]
+
+  # Assign very high sentinel price if missing, so it won't be picked
+  prices = [for p in local.paid_tariffs : try(p.unit_int_price_per_hour, 999999999)]
+
+  # Find index of cheapest paid tariff
+  min_price = try(min(local.prices...), null)
+  min_idx   = can(local.min_price) ? index(local.prices, local.min_price) : 0
+
+  # Final selection: cheapest paid if any; otherwise fall back to first package
+  cheapest_paid_tariff = length(local.paid_tariffs) > 0 ? local.paid_tariffs[local.min_idx] : local.resource_data[0]
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name           = "tf-acc-test-cluster-backup-res-del"
 	account_id     = local.account_id
-	cloud_region   = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	# Ignore enum defaults the API returns but rejects on create (enum 0)
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
 
 	configuration {
 		number_of_nodes = 1
 
 		node_configuration {
-			package_id = local.first_free_tariff.id
+			package_id = local.cheapest_paid_tariff.id
 		}
 	}
 }
 
 resource "qdrant-cloud_accounts_backup_schedule" "test" {
-	cluster_id                  = qdrant-cloud_accounts_cluster.test.id
-	cron_expression             = "0 0 2 * *" // Run at 2am on the 2nd of every month
-	retention_period            = "240h"      // 10 days
-	delete_backups_on_destroy   = false
+	cluster_id                = qdrant-cloud_accounts_cluster.test.id
+	cron_expression           = "0 0 2 * *" # Run at 2am on the 2nd of every month
+	retention_period          = "240h"      # 10 days
+	delete_backups_on_destroy = false
 }
-	`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+	`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	check := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("qdrant-cloud_accounts_backup_schedule.test", "cron_expression", "0 0 2 * *"),
+		resource.TestCheckResourceAttr("qdrant-cloud_accounts_backup_schedule.test", "retention_period", "240h0m0s"),
 		resource.TestCheckResourceAttr("qdrant-cloud_accounts_backup_schedule.test", "delete_backups_on_destroy", "false"),
 	)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
-			{Config: config, Check: check, Destroy: true},
+			{
+				Config: config,
+				Check:  check,
+			},
+			{
+				Config:       provider,
+				ResourceName: "qdrant-cloud_accounts_backup_schedule.test",
+				Destroy:      true,
+			},
 		},
 	})
 }

--- a/qdrant/resource_accounts_cluster_test.go
+++ b/qdrant/resource_accounts_cluster_test.go
@@ -9,53 +9,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestResourceClusterCreate(t *testing.T) {
+func TestAccResourceClusterCreate(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "gcp")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "europe-west3")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-    	cloud_provider = "gcp"
-		cloud_region = "us-east4"
-}
-locals {
-  resource_data = data.qdrant-cloud_booking_packages.test.packages
-  // Filter on gpx1 
-  gpx1_packages = [
-    for resource in local.resource_data : resource if resource.name == "gpx1"
-  ]
-  // Get the first gpx1 package
-  gpx1_package = local.gpx1_packages[0]
-}
-
-resource "qdrant-cloud_accounts_cluster" "test" {
-	name = "test-cluster"
-	account_id = "%s"
-	cloud_region = "us-east4"
-	cloud_provider = "gcp"
-
-	configuration {
-		number_of_nodes = 1
-
-		node_configuration {
-			package_id = local.gpx1_package.id
-		}
-	}
-}
-
-output "cluster_name" {
-	value = qdrant-cloud_accounts_cluster.test.name
-}
-
-`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
-
-	config_update := provider + fmt.Sprintf(`
-data "qdrant-cloud_booking_packages" "test" {
-		cloud_provider = "gcp"
-		cloud_region = "us-east4"
+	cloud_provider = "%s"
+	cloud_region   = "%s"
 }
 locals {
   resource_data = data.qdrant-cloud_booking_packages.test.packages
@@ -70,8 +39,54 @@ locals {
 resource "qdrant-cloud_accounts_cluster" "test" {
 	name           = "test-cluster"
 	account_id     = "%s"
-	cloud_region   = "us-east4"
-	cloud_provider = "gcp"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
+
+	lifecycle {
+	  ignore_changes = [
+	    configuration[0].gpu_type,
+	    configuration[0].rebalance_strategy,
+	    configuration[0].restart_policy,
+	    configuration[0].service_type,
+	    configuration[0].allowed_ip_source_ranges,
+	    configuration[0].database_configuration,
+	  ]
+	}
+
+	configuration {
+		number_of_nodes = 1
+
+		node_configuration {
+			package_id = local.gpx1_package.id
+		}
+	}
+}
+
+output "cluster_name" {
+	value = qdrant-cloud_accounts_cluster.test.name
+}
+`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
+
+	config_update := provider + fmt.Sprintf(`
+data "qdrant-cloud_booking_packages" "test" {
+	cloud_provider = "%s"
+	cloud_region   = "%s"
+}
+locals {
+  resource_data = data.qdrant-cloud_booking_packages.test.packages
+  // Filter on gpx1 
+  gpx1_packages = [
+    for resource in local.resource_data : resource if resource.name == "gpx1"
+  ]
+  // Get the first gpx1 package
+  gpx1_package = local.gpx1_packages[0]
+}
+
+resource "qdrant-cloud_accounts_cluster" "test" {
+	name           = "test-cluster"
+	account_id     = "%s"
+	cloud_region   = "%s"
+	cloud_provider = "%s"
 
 	configuration {
 		number_of_nodes = 2   // Update the number of nodes to 2
@@ -89,8 +104,7 @@ output "cluster_name" {
 output "cluster_cfg_num_nodes" {
 	value = qdrant-cloud_accounts_cluster.test.configuration[0].number_of_nodes
 }
-
-`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	t.Run("creates a cluster", func(t *testing.T) {
 		testCase := func(t *testing.T, _ string) {
@@ -123,17 +137,22 @@ output "cluster_cfg_num_nodes" {
 	})
 }
 
-func TestResourceClusterCreateWithExtraDisk(t *testing.T) {
+func TestAccResourceClusterCreateWithExtraDisk(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "gcp")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "europe-west3")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-  cloud_provider = "gcp"
-  cloud_region   = "us-east4"
+  cloud_provider = "%s"
+  cloud_region   = "%s"
 }
 locals {
   resource_data = data.qdrant-cloud_booking_packages.test.packages
@@ -148,8 +167,19 @@ locals {
 resource "qdrant-cloud_accounts_cluster" "test" {
   name           = "test-cluster-with-extra-disk"
   account_id     = "%s"
-  cloud_region   = "us-east4"
-  cloud_provider = "gcp"
+  cloud_region   = "%s"
+  cloud_provider = "%s"
+
+  lifecycle {
+    ignore_changes = [
+      configuration[0].gpu_type,
+      configuration[0].rebalance_strategy,
+      configuration[0].restart_policy,
+      configuration[0].service_type,
+      configuration[0].allowed_ip_source_ranges,
+      configuration[0].database_configuration,
+    ]
+  }
 
   configuration {
     number_of_nodes = 1
@@ -172,8 +202,7 @@ output "cluster_name" {
 output "extra_disk_amount" {
   value = qdrant-cloud_accounts_cluster.test.configuration[0].node_configuration[0].resource_configurations[0].amount
 }
-
-`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	t.Run("creates a cluster with extra disk", func(t *testing.T) {
 		testCase := func(t *testing.T, _ string) {
@@ -200,17 +229,22 @@ output "extra_disk_amount" {
 	})
 }
 
-func TestResourceClusterDeleteWithoutBackups(t *testing.T) {
+func TestAccResourceClusterDeleteWithoutBackups(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	cloudProvider := getEnvDefault("QDRANT_CLOUD_CLOUD_PROVIDER", "gcp")
+	cloudRegion := getEnvDefault("QDRANT_CLOUD_REGION", "europe-west3")
+
 	provider := fmt.Sprintf(`
 provider "qdrant-cloud" {
   api_key = "%s"
 }
-	`, os.Getenv("QDRANT_CLOUD_API_KEY"))
+	`, apiKey)
 
 	config := provider + fmt.Sprintf(`
 data "qdrant-cloud_booking_packages" "test" {
-  cloud_provider = "gcp"
-  cloud_region   = "us-east4"
+  cloud_provider = "%s"
+  cloud_region   = "%s"
 }
 locals {
   resource_data = data.qdrant-cloud_booking_packages.test.packages
@@ -223,10 +257,10 @@ locals {
 }
 
 resource "qdrant-cloud_accounts_cluster" "test" {
-  name           = "test-cluster-delete-no-backups"
-  account_id     = "%s"
-  cloud_region   = "us-east4"
-  cloud_provider = "gcp"
+  name                      = "test-cluster-delete-no-backups"
+  account_id                = "%s"
+  cloud_region              = "%s"
+  cloud_provider            = "%s"
   delete_backups_on_destroy = false
 
   configuration {
@@ -241,14 +275,13 @@ resource "qdrant-cloud_accounts_cluster" "test" {
 output "cluster_name_del" {
   value = qdrant-cloud_accounts_cluster.test.name
 }
-`, os.Getenv("QDRANT_CLOUD_ACCOUNT_ID"))
+`, cloudProvider, cloudRegion, accountID, cloudRegion, cloudProvider)
 
 	t.Run("creates and deletes a cluster without deleting backups", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: map[string]func() (*schema.Provider, error){
-				"qdrant-cloud": func() (*schema.Provider, error) { //nolint: unparam // (error) is always nil
-					return Provider(), nil
-				},
+				//nolint:unparam // Ignoring unparam as we know error will always be nil
+				"qdrant-cloud": func() (*schema.Provider, error) { return Provider(), nil },
 			},
 			Steps: []resource.TestStep{
 				{

--- a/qdrant/schemas_accounts_backup_schedules.go
+++ b/qdrant/schemas_accounts_backup_schedules.go
@@ -39,8 +39,8 @@ func accountsBackupScheduleResourceSchema(asDataSource bool) map[string]*schema.
 		backupScheduleClusterIDFieldName: {
 			Description: fmt.Sprintf(backupScheduleFieldTemplate, "Cluster ID"),
 			Type:        schema.TypeString,
-			Required:    !asDataSource,
-			Computed:    asDataSource,
+			Required:    true,
+			Computed:    false,
 			ForceNew:    !asDataSource,
 		},
 		backupScheduleCronExpressionFieldName: {


### PR DESCRIPTION
[Ticket](https://qdrant.atlassian.net/browse/CP-288)

1. **Region Handling**  
   - Replaced hardcoded `GCP::europe-west3` with environment-driven configuration.  
   - Default region is now `AWS::eu-central-1` since the previous GCP region no longer exists in staging/development.

2. **Tariff Selection**  
   - Acceptance tests now use the **cheapest paid tariff** for cluster creation.  
   - This avoids issues caused by free-tier resource limitations.

3. **Stability Improvements**  
   - Added proper waiting intervals before validation to ensure resources are fully provisioned.

4. **CI Enhancements**  
   - Introduced a new **GitHub Actions workflow step** to run both **unit** and **acceptance** tests.  
   - Supports repository-level variables (e.g., `SKIPPED_TESTS`, `QDRANT_CLOUD_API_URL`).
  
<img width="592" height="329" alt="Screenshot 2025-10-27 at 09 47 17" src="https://github.com/user-attachments/assets/a55074e1-846c-4515-9523-f03dfae9f121" />

