### PR TITLE
Adds restore_package_id and resources_summary into backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,20 @@ make test.acceptance \
   SKIPPED_TESTS="TestAccDataAccountsBackupSchedule TestAccResourceClusterCreate"
 ```
 
-or run a single test /wo make (not acceptance and not extra env vars are required);
+or run a single **unit** test without `make` (acceptance tests still require the env vars from above);
 
 ```bash
 go test -v ./... -run '^TestFlattenHCEnv$'
+```
+
+to run a single **acceptance** test, export `TF_ACC=1` plus the required Qdrant credentials and target the specific `TestAcc*`:
+
+```bash
+TF_ACC=1 \
+  QDRANT_CLOUD_API_KEY="<API_KEY>" \
+  QDRANT_CLOUD_ACCOUNT_ID="<ACCOUNT_ID>" \
+  QDRANT_CLOUD_API_URL="grpc.development-cloud.qdrant.io" \
+  go test -count=1 -v ./qdrant -run '^TestAccResourceAccountsUserRoles_Update$'
 ```
 
 ## Releasing

--- a/docs/resources/accounts_manual_backup.md
+++ b/docs/resources/accounts_manual_backup.md
@@ -116,6 +116,8 @@ Read-Only:
 - `cloud_provider_region_id` (String)
 - `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cluster_info--configuration))
 - `name` (String)
+- `resources_summary` (List of Object) (see [below for nested schema](#nestedobjatt--cluster_info--resources_summary))
+- `restore_package_id` (String)
 
 <a id="nestedobjatt--cluster_info--configuration"></a>
 ### Nested Schema for `cluster_info.configuration`
@@ -317,6 +319,43 @@ Read-Only:
 - `operator` (String)
 - `toleration_seconds` (Number)
 - `value` (String)
+
+
+
+<a id="nestedobjatt--cluster_info--resources_summary"></a>
+### Nested Schema for `cluster_info.resources_summary`
+
+Read-Only:
+
+- `cpu` (List of Object) (see [below for nested schema](#nestedobjatt--cluster_info--resources_summary--cpu))
+- `disk` (List of Object) (see [below for nested schema](#nestedobjatt--cluster_info--resources_summary--disk))
+- `ram` (List of Object) (see [below for nested schema](#nestedobjatt--cluster_info--resources_summary--ram))
+
+<a id="nestedobjatt--cluster_info--resources_summary--cpu"></a>
+### Nested Schema for `cluster_info.resources_summary.cpu`
+
+Read-Only:
+
+- `amount` (Number)
+- `unit` (String)
+
+
+<a id="nestedobjatt--cluster_info--resources_summary--disk"></a>
+### Nested Schema for `cluster_info.resources_summary.disk`
+
+Read-Only:
+
+- `amount` (Number)
+- `unit` (String)
+
+
+<a id="nestedobjatt--cluster_info--resources_summary--ram"></a>
+### Nested Schema for `cluster_info.resources_summary.ram`
+
+Read-Only:
+
+- `amount` (Number)
+- `unit` (String)
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
-	github.com/qdrant/qdrant-cloud-public-api v0.76.0
+	github.com/qdrant/qdrant-cloud-public-api v0.77.1
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/qdrant/qdrant-cloud-public-api v0.76.0 h1:/yvQadX+9GAf0omR/D9lCBUIUrpKpjnD/j/OHqTZ/jk=
-github.com/qdrant/qdrant-cloud-public-api v0.76.0/go.mod h1:XqgxNTOYlCx1d6UKbPjttSyORF3WCvZefOpYTlBcJ8g=
+github.com/qdrant/qdrant-cloud-public-api v0.77.1 h1:CPSDX5Pv+JCF/JfVzB+Q2Pm32B6kl6lHzSzxdQoaB5E=
+github.com/qdrant/qdrant-cloud-public-api v0.77.1/go.mod h1:XqgxNTOYlCx1d6UKbPjttSyORF3WCvZefOpYTlBcJ8g=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/qdrant/acc_test_helpers.go
+++ b/qdrant/acc_test_helpers.go
@@ -1,10 +1,20 @@
 package qdrant
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	qcb "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/backup/v1"
 )
 
 // testCheckHasListAttr verifies a list attribute has at least one element.
@@ -60,4 +70,87 @@ func testAccCheckAttrEqual(name1, attr1, name2, attr2 string) resource.TestCheck
 		}
 		return nil
 	}
+}
+
+// testAccWaitForBackupStatus polls the backup service until the given resource reaches the desired status or times out.
+// It fails fast if the backup transitions to FAILED.
+func testAccWaitForBackupStatus(resourceName string, desired qcb.BackupStatus, timeout time.Duration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		backupID := rs.Primary.ID
+		if backupID == "" {
+			return fmt.Errorf("resource %s missing ID", resourceName)
+		}
+		accountID := rs.Primary.Attributes["account_id"]
+		if accountID == "" {
+			accountID = os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+		}
+		if accountID == "" {
+			return fmt.Errorf("account_id not found for %s", resourceName)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		client, clientCtx, closeFn, err := newTestAccBackupServiceClient(ctx)
+		if err != nil {
+			return err
+		}
+		defer closeFn()
+
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		var lastStatus qcb.BackupStatus
+		var lastErr error
+		for {
+			resp, err := client.GetBackup(clientCtx, &qcb.GetBackupRequest{
+				AccountId: accountID,
+				BackupId:  backupID,
+			})
+			if err != nil {
+				lastErr = err
+			} else if resp.GetBackup() != nil {
+				lastStatus = resp.GetBackup().GetStatus()
+				switch lastStatus {
+				case desired:
+					return nil
+				case qcb.BackupStatus_BACKUP_STATUS_FAILED:
+					return fmt.Errorf("backup %s entered failed status while waiting for %s", backupID, desired)
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				if lastErr != nil {
+					return fmt.Errorf("timeout waiting for backup %s to reach %s (last error: %w)", backupID, desired, lastErr)
+				}
+				return fmt.Errorf("timeout waiting for backup %s to reach %s (last status: %s)", backupID, desired, lastStatus)
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
+// newTestAccBackupServiceClient dials the backup service using the TF_ACC credentials and returns a client, context with auth headers, and close func.
+func newTestAccBackupServiceClient(ctx context.Context) (qcb.BackupServiceClient, context.Context, func(), error) {
+	apiKey := strings.TrimSpace(os.Getenv("QDRANT_CLOUD_API_KEY"))
+	if apiKey == "" {
+		return nil, nil, nil, fmt.Errorf("QDRANT_CLOUD_API_KEY not set")
+	}
+	apiURL := strings.TrimSpace(os.Getenv("QDRANT_CLOUD_API_URL"))
+	if apiURL == "" {
+		apiURL = "grpc.cloud.qdrant.io"
+	}
+	insecure := strings.EqualFold(os.Getenv("QDRANT_CLOUD_INSECURE"), "true")
+	creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: insecure})
+	conn, err := grpc.NewClient(apiURL, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("dial backup service: %w", err)
+	}
+	clientCtx := metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("apikey %s", apiKey))
+	closeFn := func() { _ = conn.Close() }
+	return qcb.NewBackupServiceClient(conn), clientCtx, closeFn, nil
 }

--- a/qdrant/resource_accounts_auth_key_test.go
+++ b/qdrant/resource_accounts_auth_key_test.go
@@ -71,6 +71,12 @@ resource "qdrant-cloud_accounts_cluster" "test" {
 		node_configuration {
 			package_id = local.cheapest_paid_tariff.id
 		}
+
+		database_configuration {
+			service {
+				jwt_rbac = false
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Adds restore_package_id and resources_summary into backup.

- Surface the new proto fields (restore_package_id, resources_summary) through the Terraform schema, flatteners, docs, and tests so the provider matches the latest public API.
- Acceptance tests now poll the backup service instead of hard-sleeping, cluster/retention flows include a stabilization step so they wait only as long as needed. 
- Updated the auth-key acceptance config to explicitly disable JWT RBAC (new API default) to keep those tests green.

Overall the provider now exposes the richer backup metadata and the acceptance suite is both more reliable and faster by avoiding blind sleeps.
