### PR TITLE
CP-393: Fix perpetual diffs for unspecified fields in cluster resource

### DIFF
--- a/qdrant/resource_accounts_cluster_test.go
+++ b/qdrant/resource_accounts_cluster_test.go
@@ -42,16 +42,6 @@ resource "qdrant-cloud_accounts_cluster" "test" {
 	cloud_region   = "%s"
 	cloud_provider = "%s"
 
-	lifecycle {
-	  ignore_changes = [
-	    configuration[0].gpu_type,
-	    configuration[0].rebalance_strategy,
-	    configuration[0].restart_policy,
-	    configuration[0].service_type,
-	    configuration[0].allowed_ip_source_ranges,
-	    configuration[0].database_configuration,
-	  ]
-	}
 
 	configuration {
 		number_of_nodes = 1
@@ -170,16 +160,6 @@ resource "qdrant-cloud_accounts_cluster" "test" {
   cloud_region   = "%s"
   cloud_provider = "%s"
 
-  lifecycle {
-    ignore_changes = [
-      configuration[0].gpu_type,
-      configuration[0].rebalance_strategy,
-      configuration[0].restart_policy,
-      configuration[0].service_type,
-      configuration[0].allowed_ip_source_ranges,
-      configuration[0].database_configuration,
-    ]
-  }
 
   configuration {
     number_of_nodes = 1
@@ -335,16 +315,6 @@ resource "qdrant-cloud_accounts_cluster" "advanced" {
   cloud_region   = "%s"
   cloud_provider = "%s"
 
-  lifecycle {
-    ignore_changes = [
-      configuration[0].gpu_type,
-      configuration[0].rebalance_strategy,
-      configuration[0].restart_policy,
-      configuration[0].service_type,
-      configuration[0].allowed_ip_source_ranges,
-      configuration[0].database_configuration,
-    ]
-  }
 
   configuration {
     number_of_nodes            = 1

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -280,7 +280,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "The node selector for this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(asDataSource),
 			},
@@ -290,7 +290,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "List of tolerations for this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: tolerationSchema(asDataSource),
 			},
@@ -300,7 +300,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "List of topology spread constraints for this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: topologySpreadConstraintSchema(asDataSource),
 			},
@@ -310,7 +310,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "List of annotations for this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(asDataSource),
 			},
@@ -320,7 +320,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "List of allowed IP source ranges for this cluster.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
@@ -330,13 +330,13 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "The type of service to use for this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		serviceAnnotationsFieldName: {
 			Description: "List of annotations applied to the service of this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(asDataSource),
 			},
@@ -346,7 +346,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "List of labels applied to the pods of this cluster in a hybrid cloud environment.",
 			Type:        schema.TypeSet,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(asDataSource),
 			},
@@ -356,7 +356,7 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "Configuration for the Qdrant database engine, primarily for hybrid cloud setups.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationSchema(asDataSource),
@@ -366,31 +366,31 @@ func accountsClusterConfigurationSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "The percentage of CPU resources reserved for system components.",
 			Type:        schema.TypeInt,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigReservedMemoryPercentageFieldName: {
 			Description: "The percentage of RAM resources reserved for system components.",
 			Type:        schema.TypeInt,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigGpuTypeFieldName: {
 			Description: "The GPU type that should be used for the database.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigRestartPolicyFieldName: {
 			Description: "The restart policy for the database.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigRebalanceStrategyFieldName: {
 			Description: "The automatic shard rebalancing strategy for the database.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 	}
 }
@@ -451,7 +451,7 @@ func databaseConfigurationSchema(asDataSource bool) map[string]*schema.Schema {
 			Description: "Default collection parameters.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationCollectionSchema(asDataSource),
@@ -461,7 +461,7 @@ func databaseConfigurationSchema(asDataSource bool) map[string]*schema.Schema {
 			Description: "Storage-related configuration.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationStorageSchema(asDataSource),
@@ -471,7 +471,7 @@ func databaseConfigurationSchema(asDataSource bool) map[string]*schema.Schema {
 			Description: "Service-related configuration.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationServiceSchema(asDataSource),
@@ -481,13 +481,13 @@ func databaseConfigurationSchema(asDataSource bool) map[string]*schema.Schema {
 			Description: "Logging level for the database.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigTlsFieldName: {
 			Description: "TLS configuration for the database.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationTlsSchema(asDataSource),
@@ -507,7 +507,7 @@ func databaseConfigurationSchema(asDataSource bool) map[string]*schema.Schema {
 			Description: "Audit logging configuration for the Qdrant database.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem: &schema.Resource{
 				Schema: databaseConfigurationAuditLoggingSchema(asDataSource),
@@ -526,24 +526,24 @@ func databaseConfigurationCollectionSchema(asDataSource bool) map[string]*schema
 		dbConfigCollectionReplicationFactor: {
 			Type:     schema.TypeInt,
 			Optional: !asDataSource,
-			Computed: asDataSource,
+			Computed: true,
 		},
 		dbConfigCollectionWriteConsistencyFactor: {
 			Type:     schema.TypeInt,
 			Optional: !asDataSource,
-			Computed: asDataSource,
+			Computed: true,
 		},
 		dbConfigCollectionVectorsFieldName: {
 			Type:     schema.TypeList,
 			Optional: !asDataSource,
-			Computed: asDataSource,
+			Computed: true,
 			MaxItems: maxItems,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					dbConfigCollectionVectorsOnDiskFieldName: {
 						Type:     schema.TypeBool,
 						Optional: !asDataSource,
-						Computed: asDataSource,
+						Computed: true,
 					},
 				},
 			},
@@ -561,19 +561,19 @@ func databaseConfigurationStorageSchema(asDataSource bool) map[string]*schema.Sc
 		dbConfigStoragePerformanceFieldName: {
 			Type:     schema.TypeList,
 			Optional: !asDataSource,
-			Computed: asDataSource,
+			Computed: true,
 			MaxItems: maxItems,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					dbConfigStoragePerfOptimizerCpuBudget: {
 						Type:     schema.TypeInt,
 						Optional: !asDataSource,
-						Computed: asDataSource,
+						Computed: true,
 					},
 					dbConfigStoragePerfAsyncScorer: {
 						Type:     schema.TypeBool,
 						Optional: !asDataSource,
-						Computed: asDataSource,
+						Computed: true,
 					},
 				},
 			},
@@ -600,7 +600,7 @@ func databaseConfigurationServiceSchema(asDataSource bool) map[string]*schema.Sc
 			Description: "Secret to use for the read-only API key.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem:        secretKeyRefSchema(asDataSource),
 		},
@@ -634,7 +634,7 @@ func databaseConfigurationTlsSchema(asDataSource bool) map[string]*schema.Schema
 			Description: "Secret to use for the certificate.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem:        secretKeyRefSchema(asDataSource),
 		},
@@ -642,7 +642,7 @@ func databaseConfigurationTlsSchema(asDataSource bool) map[string]*schema.Schema
 			Description: "Secret to use for the private key.",
 			Type:        schema.TypeList,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 			MaxItems:    maxItems,
 			Elem:        secretKeyRefSchema(asDataSource),
 		},
@@ -667,25 +667,25 @@ func databaseConfigurationAuditLoggingSchema(asDataSource bool) map[string]*sche
 			Description: "If true, the cluster is configured to use audit logging.",
 			Type:        schema.TypeBool,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigAuditLoggingRotationFieldName: {
 			Description: "Rotation interval for audit logs. Possible values: AUDIT_LOG_ROTATION_DAILY, AUDIT_LOG_ROTATION_HOURLY.",
 			Type:        schema.TypeString,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigAuditLoggingMaxLogFilesFieldName: {
 			Description: "Maximum number of rotated audit log files to keep. Default is 7.",
 			Type:        schema.TypeInt,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 		dbConfigAuditLoggingTrustForwardedHeadersFieldName: {
 			Description: "Whether to use the X-Forwarded-For header to determine the client address in audit log entries. Relevant for hybrid cloud clusters only.",
 			Type:        schema.TypeBool,
 			Optional:    !asDataSource,
-			Computed:    asDataSource,
+			Computed:    true,
 		},
 	}
 }

--- a/qdrant/schemas_accounts_clusters_test.go
+++ b/qdrant/schemas_accounts_clusters_test.go
@@ -575,6 +575,375 @@ func TestExpandClusterConfiguration_EmptyAllowedIpSourceRangesReturnsNil(t *test
 	})
 }
 
+// TestClusterConfigSchemaEnumFieldsAreOptionalAndComputed verifies that enum and
+// backend-managed fields are both Optional and Computed in resource mode.
+// This prevents perpetual diffs when the backend returns UNSPECIFIED or default values
+// for fields the user didn't set.
+func TestClusterConfigSchemaEnumFieldsAreOptionalAndComputed(t *testing.T) {
+	schemaMap := accountsClusterConfigurationSchema(false) // resource mode
+	fieldsToCheck := []string{
+		serviceTypeFieldName,
+		dbConfigGpuTypeFieldName,
+		dbConfigRestartPolicyFieldName,
+		dbConfigRebalanceStrategyFieldName,
+		dbConfigReservedCpuPercentageFieldName,
+		dbConfigReservedMemoryPercentageFieldName,
+		databaseConfigurationFieldName,
+	}
+	for _, field := range fieldsToCheck {
+		t.Run(field, func(t *testing.T) {
+			s, ok := schemaMap[field]
+			require.True(t, ok, "field %s should exist in schema", field)
+			assert.True(t, s.Optional, "field %s should be Optional", field)
+			assert.True(t, s.Computed, "field %s should be Computed to prevent perpetual diffs with UNSPECIFIED backend values", field)
+		})
+	}
+}
+
+// TestClusterConfigSchemaDataSourceFieldsAreComputed verifies that the same fields
+// are Computed (and not Optional) in data source mode.
+func TestDatabaseConfigSchemaFieldsAreOptionalAndComputed(t *testing.T) {
+	schemaMap := databaseConfigurationSchema(false)
+	fieldsToCheck := []string{
+		dbConfigCollectionFieldName,
+		dbConfigStorageFieldName,
+		dbConfigServiceFieldName,
+		dbConfigLogLevelFieldName,
+		dbConfigTlsFieldName,
+	}
+	for _, field := range fieldsToCheck {
+		t.Run(field, func(t *testing.T) {
+			s, ok := schemaMap[field]
+			require.True(t, ok, "field %s should exist in schema", field)
+			assert.True(t, s.Optional, "field %s should be Optional", field)
+			assert.True(t, s.Computed, "field %s should be Computed to prevent perpetual diffs", field)
+		})
+	}
+}
+
+// TestOptionalFieldsMustBeComputed ensures that every Optional field in the
+// cluster configuration schema (resource mode) also has Computed: true.
+// If the backend can return a value for a field the user didn't set,
+// Terraform needs Computed: true to avoid perpetual diffs.
+// This test prevents regressions when new Optional fields are added.
+func TestOptionalFieldsMustBeComputed(t *testing.T) {
+	schemas := map[string]map[string]*schema.Schema{
+		"clusterConfiguration":  accountsClusterConfigurationSchema(false),
+		"databaseConfiguration": databaseConfigurationSchema(false),
+		"databaseCollection":    databaseConfigurationCollectionSchema(false),
+		"databaseStorage":       databaseConfigurationStorageSchema(false),
+		"databaseService":       databaseConfigurationServiceSchema(false),
+		"databaseTls":           databaseConfigurationTlsSchema(false),
+		"databaseAuditLogging":  databaseConfigurationAuditLoggingSchema(false),
+	}
+
+	for schemaName, schemaMap := range schemas {
+		for fieldName, fieldSchema := range schemaMap {
+			if fieldSchema.Optional && fieldSchema.Deprecated == "" {
+				t.Run(schemaName+"/"+fieldName, func(t *testing.T) {
+					assert.True(t, fieldSchema.Computed,
+						"field %s in %s is Optional but not Computed — the backend may populate this field, "+
+							"causing perpetual Terraform diffs. Change Computed to true.",
+						fieldName, schemaName)
+				})
+			}
+		}
+	}
+}
+
+func TestClusterConfigSchemaDataSourceFieldsAreComputed(t *testing.T) {
+	schemaMap := accountsClusterConfigurationSchema(true) // data source mode
+	fieldsToCheck := []string{
+		serviceTypeFieldName,
+		dbConfigGpuTypeFieldName,
+		dbConfigRestartPolicyFieldName,
+		dbConfigRebalanceStrategyFieldName,
+		dbConfigReservedCpuPercentageFieldName,
+		dbConfigReservedMemoryPercentageFieldName,
+	}
+	for _, field := range fieldsToCheck {
+		t.Run(field, func(t *testing.T) {
+			s, ok := schemaMap[field]
+			require.True(t, ok, "field %s should exist in schema", field)
+			assert.False(t, s.Optional, "field %s should not be Optional in data source mode", field)
+			assert.True(t, s.Computed, "field %s should be Computed in data source mode", field)
+		})
+	}
+}
+
+// TestFlattenClusterConfigurationExplicitUnspecifiedPointers verifies that even when
+// the backend explicitly sends UNSPECIFIED enum pointers (not just nil), they are
+// excluded from the flattened output.
+func TestFlattenClusterConfigurationExplicitUnspecifiedPointers(t *testing.T) {
+	clusterConfig := &qcCluster.ClusterConfiguration{
+		NumberOfNodes:     1,
+		PackageId:         "test-package-id",
+		ServiceType:       newPointer(qcCluster.ClusterServiceType_CLUSTER_SERVICE_TYPE_UNSPECIFIED),
+		GpuType:           newPointer(qcCluster.ClusterConfigurationGpuType_CLUSTER_CONFIGURATION_GPU_TYPE_UNSPECIFIED),
+		RestartPolicy:     newPointer(qcCluster.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_UNSPECIFIED),
+		RebalanceStrategy: newPointer(qcCluster.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_UNSPECIFIED),
+	}
+
+	flattened := flattenClusterConfiguration(clusterConfig, nil)
+
+	require.Len(t, flattened, 1)
+	configMap := flattened[0].(map[string]interface{})
+
+	_, hasServiceType := configMap[serviceTypeFieldName]
+	_, hasGpuType := configMap[dbConfigGpuTypeFieldName]
+	_, hasRestartPolicy := configMap[dbConfigRestartPolicyFieldName]
+	_, hasRebalanceStrategy := configMap[dbConfigRebalanceStrategyFieldName]
+
+	assert.False(t, hasServiceType, "service_type should not be present when explicitly UNSPECIFIED")
+	assert.False(t, hasGpuType, "gpu_type should not be present when explicitly UNSPECIFIED")
+	assert.False(t, hasRestartPolicy, "restart_policy should not be present when explicitly UNSPECIFIED")
+	assert.False(t, hasRebalanceStrategy, "rebalance_strategy should not be present when explicitly UNSPECIFIED")
+}
+
+// TestFlattenClusterConfigurationAllEnumValues verifies that every non-UNSPECIFIED
+// enum value for each field is correctly included in the flattened output.
+func TestFlattenClusterConfigurationAllEnumValues(t *testing.T) {
+	t.Run("all ServiceType values", func(t *testing.T) {
+		for val, name := range qcCluster.ClusterServiceType_name {
+			if val == 0 {
+				continue // skip UNSPECIFIED
+			}
+			t.Run(name, func(t *testing.T) {
+				cfg := &qcCluster.ClusterConfiguration{
+					ServiceType: newPointer(qcCluster.ClusterServiceType(val)),
+				}
+				flattened := flattenClusterConfiguration(cfg, nil)
+				configMap := flattened[0].(map[string]interface{})
+				assert.Equal(t, name, configMap[serviceTypeFieldName])
+			})
+		}
+	})
+
+	t.Run("all GpuType values", func(t *testing.T) {
+		for val, name := range qcCluster.ClusterConfigurationGpuType_name {
+			if val == 0 {
+				continue
+			}
+			t.Run(name, func(t *testing.T) {
+				cfg := &qcCluster.ClusterConfiguration{
+					GpuType: newPointer(qcCluster.ClusterConfigurationGpuType(val)),
+				}
+				flattened := flattenClusterConfiguration(cfg, nil)
+				configMap := flattened[0].(map[string]interface{})
+				assert.Equal(t, name, configMap[dbConfigGpuTypeFieldName])
+			})
+		}
+	})
+
+	t.Run("all RestartPolicy values", func(t *testing.T) {
+		for val, name := range qcCluster.ClusterConfigurationRestartPolicy_name {
+			if val == 0 {
+				continue
+			}
+			t.Run(name, func(t *testing.T) {
+				cfg := &qcCluster.ClusterConfiguration{
+					RestartPolicy: newPointer(qcCluster.ClusterConfigurationRestartPolicy(val)),
+				}
+				flattened := flattenClusterConfiguration(cfg, nil)
+				configMap := flattened[0].(map[string]interface{})
+				assert.Equal(t, name, configMap[dbConfigRestartPolicyFieldName])
+			})
+		}
+	})
+
+	t.Run("all RebalanceStrategy values", func(t *testing.T) {
+		for val, name := range qcCluster.ClusterConfigurationRebalanceStrategy_name {
+			if val == 0 {
+				continue
+			}
+			t.Run(name, func(t *testing.T) {
+				cfg := &qcCluster.ClusterConfiguration{
+					RebalanceStrategy: newPointer(qcCluster.ClusterConfigurationRebalanceStrategy(val)),
+				}
+				flattened := flattenClusterConfiguration(cfg, nil)
+				configMap := flattened[0].(map[string]interface{})
+				assert.Equal(t, name, configMap[dbConfigRebalanceStrategyFieldName])
+			})
+		}
+	})
+}
+
+// TestExpandClusterConfigurationUnspecifiedEnumStrings verifies that if UNSPECIFIED
+// string values somehow end up in the Terraform state, expand correctly ignores them
+// and does not send them to the API.
+func TestExpandClusterConfigurationUnspecifiedEnumStrings(t *testing.T) {
+	configBlock := []interface{}{
+		map[string]interface{}{
+			numberOfNodesFieldName:             1,
+			serviceTypeFieldName:               "CLUSTER_SERVICE_TYPE_UNSPECIFIED",
+			dbConfigGpuTypeFieldName:           "CLUSTER_CONFIGURATION_GPU_TYPE_UNSPECIFIED",
+			dbConfigRestartPolicyFieldName:     "CLUSTER_CONFIGURATION_RESTART_POLICY_UNSPECIFIED",
+			dbConfigRebalanceStrategyFieldName: "CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_UNSPECIFIED",
+		},
+	}
+	config, _ := expandClusterConfiguration(configBlock)
+
+	require.NotNil(t, config)
+	assert.Nil(t, config.ServiceType, "ServiceType should be nil when UNSPECIFIED string is provided")
+	assert.Nil(t, config.GpuType, "GpuType should be nil when UNSPECIFIED string is provided")
+	assert.Nil(t, config.RestartPolicy, "RestartPolicy should be nil when UNSPECIFIED string is provided")
+	assert.Nil(t, config.RebalanceStrategy, "RebalanceStrategy should be nil when UNSPECIFIED string is provided")
+}
+
+// TestExpandClusterConfigurationValidEnumStrings verifies that expand correctly
+// converts valid enum string values to their protobuf counterparts.
+func TestExpandClusterConfigurationValidEnumStrings(t *testing.T) {
+	configBlock := []interface{}{
+		map[string]interface{}{
+			numberOfNodesFieldName:             1,
+			serviceTypeFieldName:               "CLUSTER_SERVICE_TYPE_LOAD_BALANCER",
+			dbConfigGpuTypeFieldName:           "CLUSTER_CONFIGURATION_GPU_TYPE_NVIDIA",
+			dbConfigRestartPolicyFieldName:     "CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING",
+			dbConfigRebalanceStrategyFieldName: "CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT",
+		},
+	}
+	config, _ := expandClusterConfiguration(configBlock)
+
+	require.NotNil(t, config)
+	assert.Equal(t, qcCluster.ClusterServiceType_CLUSTER_SERVICE_TYPE_LOAD_BALANCER, config.GetServiceType())
+	assert.Equal(t, qcCluster.ClusterConfigurationGpuType_CLUSTER_CONFIGURATION_GPU_TYPE_NVIDIA, config.GetGpuType())
+	assert.Equal(t, qcCluster.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING, config.GetRestartPolicy())
+	assert.Equal(t, qcCluster.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT, config.GetRebalanceStrategy())
+}
+
+// TestExpandClusterConfigurationEmptyEnumStrings verifies that empty string values
+// for enum fields (the Terraform zero value) do not get sent to the API.
+func TestExpandClusterConfigurationEmptyEnumStrings(t *testing.T) {
+	configBlock := []interface{}{
+		map[string]interface{}{
+			numberOfNodesFieldName:             1,
+			serviceTypeFieldName:               "",
+			dbConfigGpuTypeFieldName:           "",
+			dbConfigRestartPolicyFieldName:     "",
+			dbConfigRebalanceStrategyFieldName: "",
+		},
+	}
+	config, _ := expandClusterConfiguration(configBlock)
+
+	require.NotNil(t, config)
+	assert.Nil(t, config.ServiceType, "ServiceType should be nil for empty string")
+	assert.Nil(t, config.GpuType, "GpuType should be nil for empty string")
+	assert.Nil(t, config.RestartPolicy, "RestartPolicy should be nil for empty string")
+	assert.Nil(t, config.RebalanceStrategy, "RebalanceStrategy should be nil for empty string")
+}
+
+// TestFlattenClusterConfigurationNilReservedPercentages verifies that nil pointer
+// values for reserved percentage fields are not included in the flattened output.
+func TestFlattenClusterConfigurationNilReservedPercentages(t *testing.T) {
+	clusterConfig := &qcCluster.ClusterConfiguration{
+		NumberOfNodes:            1,
+		PackageId:                "test-package-id",
+		ReservedCpuPercentage:    nil,
+		ReservedMemoryPercentage: nil,
+	}
+
+	flattened := flattenClusterConfiguration(clusterConfig, nil)
+
+	require.Len(t, flattened, 1)
+	configMap := flattened[0].(map[string]interface{})
+
+	_, hasCpu := configMap[dbConfigReservedCpuPercentageFieldName]
+	_, hasMem := configMap[dbConfigReservedMemoryPercentageFieldName]
+
+	assert.False(t, hasCpu, "reserved_cpu_percentage should not be present when nil")
+	assert.False(t, hasMem, "reserved_memory_percentage should not be present when nil")
+}
+
+// TestFlattenClusterConfigurationWithReservedPercentages verifies that actual
+// reserved percentage values are correctly included in the flattened output.
+func TestFlattenClusterConfigurationWithReservedPercentages(t *testing.T) {
+	clusterConfig := &qcCluster.ClusterConfiguration{
+		NumberOfNodes:            1,
+		PackageId:                "test-package-id",
+		ReservedCpuPercentage:    newPointer(uint32(10)),
+		ReservedMemoryPercentage: newPointer(uint32(20)),
+	}
+
+	flattened := flattenClusterConfiguration(clusterConfig, nil)
+
+	require.Len(t, flattened, 1)
+	configMap := flattened[0].(map[string]interface{})
+
+	assert.Equal(t, 10, configMap[dbConfigReservedCpuPercentageFieldName])
+	assert.Equal(t, 20, configMap[dbConfigReservedMemoryPercentageFieldName])
+}
+
+// TestFlattenExpandRoundTripEnumFields verifies that flatten → expand → flatten
+// produces consistent results for enum fields, ensuring no data is lost or corrupted.
+func TestFlattenExpandRoundTripEnumFields(t *testing.T) {
+	original := &qcCluster.ClusterConfiguration{
+		NumberOfNodes:     3,
+		PackageId:         "test-package-id",
+		ServiceType:       newPointer(qcCluster.ClusterServiceType_CLUSTER_SERVICE_TYPE_LOAD_BALANCER),
+		GpuType:           newPointer(qcCluster.ClusterConfigurationGpuType_CLUSTER_CONFIGURATION_GPU_TYPE_NVIDIA),
+		RestartPolicy:     newPointer(qcCluster.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING),
+		RebalanceStrategy: newPointer(qcCluster.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT),
+	}
+
+	// First flatten
+	flattened1 := flattenClusterConfiguration(original, nil)
+	require.Len(t, flattened1, 1)
+
+	// Expand back
+	expanded, _ := expandClusterConfiguration(flattened1)
+	require.NotNil(t, expanded)
+
+	// Second flatten
+	flattened2 := flattenClusterConfiguration(expanded, nil)
+	require.Len(t, flattened2, 1)
+
+	// Compare enum fields between first and second flatten
+	map1 := flattened1[0].(map[string]interface{})
+	map2 := flattened2[0].(map[string]interface{})
+
+	assert.Equal(t, map1[serviceTypeFieldName], map2[serviceTypeFieldName], "service_type should be consistent across round-trip")
+	assert.Equal(t, map1[dbConfigGpuTypeFieldName], map2[dbConfigGpuTypeFieldName], "gpu_type should be consistent across round-trip")
+	assert.Equal(t, map1[dbConfigRestartPolicyFieldName], map2[dbConfigRestartPolicyFieldName], "restart_policy should be consistent across round-trip")
+	assert.Equal(t, map1[dbConfigRebalanceStrategyFieldName], map2[dbConfigRebalanceStrategyFieldName], "rebalance_strategy should be consistent across round-trip")
+}
+
+// TestFlattenExpandRoundTripUnspecifiedEnumFields verifies that the round-trip
+// for UNSPECIFIED values is also consistent — they should remain absent.
+func TestFlattenExpandRoundTripUnspecifiedEnumFields(t *testing.T) {
+	original := &qcCluster.ClusterConfiguration{
+		NumberOfNodes: 1,
+		PackageId:     "test-package-id",
+		// All enum fields default to UNSPECIFIED (nil pointers)
+	}
+
+	// First flatten — UNSPECIFIED values should be absent
+	flattened1 := flattenClusterConfiguration(original, nil)
+	require.Len(t, flattened1, 1)
+
+	// Expand back — should produce nil enum pointers
+	expanded, _ := expandClusterConfiguration(flattened1)
+	require.NotNil(t, expanded)
+	assert.Nil(t, expanded.ServiceType)
+	assert.Nil(t, expanded.GpuType)
+	assert.Nil(t, expanded.RestartPolicy)
+	assert.Nil(t, expanded.RebalanceStrategy)
+
+	// Second flatten — should still be absent
+	flattened2 := flattenClusterConfiguration(expanded, nil)
+	require.Len(t, flattened2, 1)
+	map2 := flattened2[0].(map[string]interface{})
+
+	_, hasServiceType := map2[serviceTypeFieldName]
+	_, hasGpuType := map2[dbConfigGpuTypeFieldName]
+	_, hasRestartPolicy := map2[dbConfigRestartPolicyFieldName]
+	_, hasRebalanceStrategy := map2[dbConfigRebalanceStrategyFieldName]
+
+	assert.False(t, hasServiceType, "service_type should remain absent across round-trip")
+	assert.False(t, hasGpuType, "gpu_type should remain absent across round-trip")
+	assert.False(t, hasRestartPolicy, "restart_policy should remain absent across round-trip")
+	assert.False(t, hasRebalanceStrategy, "rebalance_strategy should remain absent across round-trip")
+}
+
 // TestFlattenClusterConfigurationSpecifiedEnums verifies that specified enum values
 // ARE included in the flattened configuration.
 func TestFlattenClusterConfigurationSpecifiedEnums(t *testing.T) {

--- a/qdrant/verify_no_diff_test.go
+++ b/qdrant/verify_no_diff_test.go
@@ -1,0 +1,139 @@
+package qdrant
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	qcCluster "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+)
+
+// TestVerifyNoPerpetualDiffWithRealCluster connects to a real Qdrant Cloud cluster,
+// fetches its configuration, flattens it, and verifies that no phantom diffs would
+// occur when the user hasn't set optional enum fields.
+//
+// This is the end-to-end proof that CP-393 is fixed:
+//  1. Fetch real cluster from the API (which returns UNSPECIFIED for unset enums)
+//  2. Flatten the response (simulating what the provider Read function does)
+//  3. Simulate an empty user config (user didn't set the enum fields)
+//  4. Compare: if the flatten output doesn't include UNSPECIFIED values,
+//     AND the schema has Computed: true, Terraform won't show a diff.
+func TestVerifyNoPerpetualDiffWithRealCluster(t *testing.T) {
+	apiKey := os.Getenv("QDRANT_CLOUD_API_KEY")
+	accountID := os.Getenv("QDRANT_CLOUD_ACCOUNT_ID")
+	apiURL := os.Getenv("QDRANT_CLOUD_API_URL")
+	if apiKey == "" || accountID == "" {
+		t.Skip("QDRANT_CLOUD_API_KEY and QDRANT_CLOUD_ACCOUNT_ID required")
+	}
+	if apiURL == "" {
+		apiURL = "grpc.development-cloud.qdrant.io"
+	}
+
+	creds := credentials.NewTLS(&tls.Config{})
+	conn, err := grpc.NewClient(apiURL, grpc.WithTransportCredentials(creds))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "Authorization", fmt.Sprintf("apikey %s", apiKey))
+	client := qcCluster.NewClusterServiceClient(conn)
+
+	resp, err := client.ListClusters(ctx, &qcCluster.ListClustersRequest{AccountId: accountID})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetItems(), "expected at least one cluster in the account")
+
+	cluster := resp.GetItems()[0]
+	cfg := cluster.GetConfiguration()
+	require.NotNil(t, cfg, "cluster should have a configuration")
+
+	t.Logf("Cluster: %s (%s)", cluster.GetName(), cluster.GetId())
+	t.Logf("Raw API values:")
+	t.Logf("  ServiceType:       %s (val=%d)", cfg.GetServiceType(), int(cfg.GetServiceType()))
+	t.Logf("  GpuType:           %s (val=%d)", cfg.GetGpuType(), int(cfg.GetGpuType()))
+	t.Logf("  RestartPolicy:     %s (val=%d)", cfg.GetRestartPolicy(), int(cfg.GetRestartPolicy()))
+	t.Logf("  RebalanceStrategy: %s (val=%d)", cfg.GetRebalanceStrategy(), int(cfg.GetRebalanceStrategy()))
+	t.Logf("  ReservedCpuPct:    %v", cfg.ReservedCpuPercentage)
+	t.Logf("  ReservedMemPct:    %v", cfg.ReservedMemoryPercentage)
+
+	flattened := flattenCluster(cluster)
+	configList := flattened[configurationFieldName].([]interface{})
+	require.Len(t, configList, 1)
+	configMap := configList[0].(map[string]interface{})
+
+	enumFields := []struct {
+		fieldName string
+		apiValue  int
+	}{
+		{serviceTypeFieldName, int(cfg.GetServiceType())},
+		{dbConfigGpuTypeFieldName, int(cfg.GetGpuType())},
+		{dbConfigRestartPolicyFieldName, int(cfg.GetRestartPolicy())},
+		{dbConfigRebalanceStrategyFieldName, int(cfg.GetRebalanceStrategy())},
+	}
+
+	for _, ef := range enumFields {
+		val, present := configMap[ef.fieldName]
+		if ef.apiValue == 0 {
+			// UNSPECIFIED (val=0) — must NOT be in flattened output
+			assert.False(t, present,
+				"field %s: backend returned UNSPECIFIED but flatten included it in state — this would cause a perpetual diff",
+				ef.fieldName)
+			t.Logf("  ✓ %s: UNSPECIFIED correctly excluded from state", ef.fieldName)
+		} else {
+			// Non-UNSPECIFIED — must be present with correct value
+			assert.True(t, present,
+				"field %s: backend returned a real value but flatten excluded it",
+				ef.fieldName)
+			t.Logf("  ✓ %s: value %q correctly included in state", ef.fieldName, val)
+		}
+	}
+
+	ptrFields := []struct {
+		fieldName string
+		isNil     bool
+	}{
+		{dbConfigReservedCpuPercentageFieldName, cfg.ReservedCpuPercentage == nil},
+		{dbConfigReservedMemoryPercentageFieldName, cfg.ReservedMemoryPercentage == nil},
+	}
+
+	for _, pf := range ptrFields {
+		_, present := configMap[pf.fieldName]
+		if pf.isNil {
+			assert.False(t, present,
+				"field %s: backend returned nil but flatten included it — this would cause a perpetual diff",
+				pf.fieldName)
+			t.Logf("  ✓ %s: nil correctly excluded from state", pf.fieldName)
+		} else {
+			assert.True(t, present,
+				"field %s: backend returned a value but flatten excluded it",
+				pf.fieldName)
+			t.Logf("  ✓ %s: value correctly included in state", pf.fieldName)
+		}
+	}
+
+	schemaMap := accountsClusterConfigurationSchema(false) // resource mode
+	computedFields := []string{
+		serviceTypeFieldName,
+		dbConfigGpuTypeFieldName,
+		dbConfigRestartPolicyFieldName,
+		dbConfigRebalanceStrategyFieldName,
+		dbConfigReservedCpuPercentageFieldName,
+		dbConfigReservedMemoryPercentageFieldName,
+	}
+	for _, field := range computedFields {
+		s := schemaMap[field]
+		require.NotNil(t, s, "field %s missing from schema", field)
+		assert.True(t, s.Optional, "field %s must be Optional", field)
+		assert.True(t, s.Computed, "field %s must be Computed — without this, Terraform shows perpetual diffs", field)
+	}
+	t.Log("  ✓ All 6 fields are Optional+Computed in resource schema")
+
+	t.Log("")
+	t.Log("No perpetual diffs: UNSPECIFIED values excluded from state, schema marks fields as Computed.")
+}


### PR DESCRIPTION
## Summary
- Change Optional fields in the cluster configuration schema and its nested schemas from `Computed: asDataSource` to `Computed: true`, preventing perpetual Terraform diffs when the backend populates fields the user didn't set
- Remove all `ignore_changes` workarounds from acceptance tests since the schema fix eliminates the diffs they were suppressing
- Add a catch-all regression test (`TestOptionalFieldsMustBeComputed`) that fails if anyone adds a new Optional field without `Computed: true`

## Root Cause
Optional fields in `accountsClusterConfigurationSchema` and its nested schemas (`databaseConfigurationSchema`, `databaseConfigurationCollectionSchema`, etc.) had `Computed: asDataSource` which evaluates to `Computed: false` for resources. With a gRPC/protobuf backend, these fields are always populated by the server — either with explicit defaults (e.g. `restart_policy = AUTOMATIC`, `service.api_key`) or zero-values (e.g. `gpu_type = UNSPECIFIED`). When Terraform sees a backend-returned value for a field marked as not-computed, it reports a diff on every plan, wanting to remove the value back to null.

The fix uses the standard `Optional+Computed` pattern for API-side defaults:
- [Google's Magic Modules docs](https://googlecloudplatform.github.io/magic-modules/develop/diffs/) — "API returns default value for unset field" section: marking a field `Optional: true, Computed: true` tells Terraform the API controls the final value when users don't configure it, preventing perpetual diffs
- [HashiCorp SDKv2 data consistency docs](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/data-consistency-errors) — documents the implicit SDKv2 behavior: `Optional+Computed` preserves the prior state value if config is removed, which is the desired behavior for backend-managed defaults
- [Google Provider best practices](https://github.com/hashicorp/terraform-provider-google/wiki/Developer-Best-Practices#optionalcomputed-lists-of-objects) — recommends `Optional+Computed` when "a field is unset, it will have a value returned by the API, but the value is unknown"

## Affected Fields
- **Cluster configuration**: service_type, gpu_type, restart_policy, rebalance_strategy, reserved_cpu_percentage, reserved_memory_percentage, database_configuration, node_selector, tolerations, topology_spread_constraints, annotations, allowed_ip_source_ranges, service_annotations, pod_labels
- **Database configuration**: collection, storage, service, log_level, tls, audit_logging
- **Nested schemas**: replication_factor, write_consistency_factor, vectors, performance, read_only_api_key, cert, key, audit logging fields

## Verification
Built the provider locally and ran `terraform import` + `terraform plan` against a real cluster on `grpc.development-cloud.qdrant.io`:

- **On `main`**: 3 phantom diffs (service_type, restart_policy, rebalance_strategy being removed to null) plus full database_configuration block drift
- **On this branch**: zero diffs (only the expected `delete_backups_on_destroy` default which is a local-only field unrelated to the API)

## Test plan
- [x] All unit tests pass
- [x] `golangci-lint` — 0 issues
- [x] `gofmt` — clean
- [x] `make generate-help` — no changes
- [x] Catch-all `TestOptionalFieldsMustBeComputed` scans all cluster configuration schemas and fails on any Optional field without `Computed: true`
- [x] Schema validation, flatten/expand, round-trip, and end-to-end tests all pass
- [x] Verified with real `terraform plan` against live cluster
- [x] CI acceptance tests pass without any `ignore_changes` workarounds