### PR TITLE
Fix cluster URL empty on first apply (#169)

### DIFF
--- a/docs/resources/accounts_cluster.md
+++ b/docs/resources/accounts_cluster.md
@@ -100,6 +100,7 @@ For hybrid this should be the hybrid cloud environment ID. field
 - `delete_backups_on_destroy` (Boolean) Whether to delete backups when the cluster is destroyed.
 - `labels` (Block Set) Cluster Schema List of labels associated with the cluster field (see [below for nested schema](#nestedblock--labels))
 - `private_region_id` (String, Deprecated) Cluster Schema Identifier of the Hybrid cloud region field
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -352,6 +353,14 @@ Required:
 
 - `key` (String)
 - `value` (String)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
 
 
 <a id="nestedatt--status"></a>

--- a/qdrant/resource_accounts_cluster.go
+++ b/qdrant/resource_accounts_cluster.go
@@ -3,8 +3,11 @@ package qdrant
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -12,6 +15,11 @@ import (
 	"google.golang.org/grpc/status"
 
 	qcCluster "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+)
+
+const (
+	clusterCreatePollInterval = 10 * time.Second
+	clusterCreateTimeout      = 20 * time.Minute
 )
 
 // resourceAccountsCluster constructs a Terraform resource for
@@ -27,6 +35,9 @@ func resourceAccountsCluster() *schema.Resource {
 		Schema:        accountsClusterSchema(false),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(clusterCreateTimeout),
 		},
 	}
 }
@@ -97,15 +108,77 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 		return diag.FromErr(fmt.Errorf("%s%s: %w", errorPrefix, reqID, err))
 	}
-	// Flatten cluster and store in Terraform state
-	for k, v := range flattenCluster(resp.GetCluster()) {
+
+	createdCluster := resp.GetCluster()
+	d.SetId(createdCluster.GetId())
+
+	accountUUID, err := getAccountUUID(d, m)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("%s: %w", errorPrefix, err))
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			clusterWaitPending,
+		},
+		Target: []string{
+			clusterWaitReady,
+		},
+		Refresh:      clusterEndpointRefreshFunc(client, clientCtx, accountUUID.String(), createdCluster.GetId()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		PollInterval: clusterCreatePollInterval,
+	}
+
+	result, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("%s: %w", errorPrefix, err))
+	}
+
+	readyCluster := result.(*qcCluster.Cluster)
+	for k, v := range flattenCluster(readyCluster) {
 		if err := d.Set(k, v); err != nil {
 			return diag.FromErr(fmt.Errorf("%s: %w", errorPrefix, err))
 		}
 	}
-	// Set the ID
-	d.SetId(resp.GetCluster().GetId())
 	return nil
+}
+
+const (
+	clusterWaitPending = "waiting"
+	clusterWaitReady   = "ready"
+)
+
+// clusterEndpointRefreshFunc returns a StateRefreshFunc that polls GetCluster
+// until the endpoint URL is populated or creation fails.
+func clusterEndpointRefreshFunc(
+	client qcCluster.ClusterServiceClient,
+	ctx context.Context,
+	accountID, clusterID string,
+) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.GetCluster(ctx, &qcCluster.GetClusterRequest{
+			AccountId: accountID,
+			ClusterId: clusterID,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+
+		cluster := resp.GetCluster()
+		phase := cluster.GetState().GetPhase()
+
+		if phase == qcCluster.ClusterPhase_CLUSTER_PHASE_FAILED_TO_CREATE {
+			return nil, "", fmt.Errorf("cluster creation failed (phase=%q reason=%q)",
+				phase.String(), cluster.GetState().GetReason())
+		}
+
+		url := strings.TrimSpace(cluster.GetState().GetEndpoint().GetUrl())
+		if url != "" {
+			return cluster, clusterWaitReady, nil
+		}
+
+		return cluster, clusterWaitPending, nil
+	}
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/qdrant/resource_accounts_cluster_test.go
+++ b/qdrant/resource_accounts_cluster_test.go
@@ -111,6 +111,7 @@ output "cluster_cfg_num_nodes" {
 						Destroy: false,
 						Check: resource.ComposeTestCheckFunc(
 							resource.TestCheckOutput("cluster_name", "test-cluster"),
+							resource.TestCheckResourceAttrSet("qdrant-cloud_accounts_cluster.test", "url"),
 						),
 					},
 					{

--- a/qdrant/resource_accounts_cluster_wait_test.go
+++ b/qdrant/resource_accounts_cluster_wait_test.go
@@ -1,0 +1,178 @@
+package qdrant
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	qcCluster "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+)
+
+type mockClusterServiceClient struct {
+	qcCluster.ClusterServiceClient
+	responses []mockGetClusterResponse
+	callCount int
+}
+
+type mockGetClusterResponse struct {
+	cluster *qcCluster.Cluster
+	err     error
+}
+
+func (m *mockClusterServiceClient) getCluster(_ context.Context) (*qcCluster.GetClusterResponse, error) {
+	idx := m.callCount
+	m.callCount++
+	if idx >= len(m.responses) {
+		idx = len(m.responses) - 1
+	}
+	r := m.responses[idx]
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &qcCluster.GetClusterResponse{Cluster: r.cluster}, nil
+}
+
+func buildRefreshFunc(mock *mockClusterServiceClient) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := mock.getCluster(context.Background())
+		if err != nil {
+			return nil, "", err
+		}
+
+		cluster := resp.GetCluster()
+		phase := cluster.GetState().GetPhase()
+
+		if phase == qcCluster.ClusterPhase_CLUSTER_PHASE_FAILED_TO_CREATE {
+			return nil, "", errors.New("cluster creation failed (phase=\"CLUSTER_PHASE_FAILED_TO_CREATE\" reason=\"" + cluster.GetState().GetReason() + "\")")
+		}
+
+		url := strings.TrimSpace(cluster.GetState().GetEndpoint().GetUrl())
+		if url != "" {
+			return cluster, clusterWaitReady, nil
+		}
+
+		return cluster, clusterWaitPending, nil
+	}
+}
+
+func TestClusterEndpointRefresh_ReturnsReadyWhenURLPresent(t *testing.T) {
+	mock := &mockClusterServiceClient{
+		responses: []mockGetClusterResponse{
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Endpoint: &qcCluster.ClusterEndpoint{Url: "https://cluster.example.com"},
+				},
+			}},
+		},
+	}
+
+	result, state, err := buildRefreshFunc(mock)()
+
+	require.NoError(t, err)
+	assert.Equal(t, clusterWaitReady, state)
+	cluster := result.(*qcCluster.Cluster)
+	assert.Equal(t, "https://cluster.example.com", cluster.GetState().GetEndpoint().GetUrl())
+}
+
+func TestClusterEndpointRefresh_ReturnsPendingWhenURLEmpty(t *testing.T) {
+	mock := &mockClusterServiceClient{
+		responses: []mockGetClusterResponse{
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Phase:    qcCluster.ClusterPhase_CLUSTER_PHASE_CREATING,
+					Endpoint: &qcCluster.ClusterEndpoint{Url: ""},
+				},
+			}},
+		},
+	}
+
+	result, state, err := buildRefreshFunc(mock)()
+
+	require.NoError(t, err)
+	assert.Equal(t, clusterWaitPending, state)
+	assert.NotNil(t, result)
+}
+
+func TestClusterEndpointRefresh_FailsFastOnFailedToCreate(t *testing.T) {
+	mock := &mockClusterServiceClient{
+		responses: []mockGetClusterResponse{
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Phase:  qcCluster.ClusterPhase_CLUSTER_PHASE_FAILED_TO_CREATE,
+					Reason: "insufficient resources",
+				},
+			}},
+		},
+	}
+
+	result, _, err := buildRefreshFunc(mock)()
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster creation failed")
+	assert.Contains(t, err.Error(), "CLUSTER_PHASE_FAILED_TO_CREATE")
+	assert.Contains(t, err.Error(), "insufficient resources")
+}
+
+func TestClusterEndpointRefresh_PropagatesAPIErrors(t *testing.T) {
+	mock := &mockClusterServiceClient{
+		responses: []mockGetClusterResponse{
+			{err: errors.New("backend unavailable")},
+		},
+	}
+
+	result, _, err := buildRefreshFunc(mock)()
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend unavailable")
+}
+
+func TestClusterEndpointRefresh_EventualSuccess(t *testing.T) {
+	mock := &mockClusterServiceClient{
+		responses: []mockGetClusterResponse{
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Phase:    qcCluster.ClusterPhase_CLUSTER_PHASE_CREATING,
+					Endpoint: &qcCluster.ClusterEndpoint{Url: ""},
+				},
+			}},
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Phase:    qcCluster.ClusterPhase_CLUSTER_PHASE_CREATING,
+					Endpoint: &qcCluster.ClusterEndpoint{Url: ""},
+				},
+			}},
+			{cluster: &qcCluster.Cluster{
+				State: &qcCluster.ClusterState{
+					Phase:    qcCluster.ClusterPhase_CLUSTER_PHASE_HEALTHY,
+					Endpoint: &qcCluster.ClusterEndpoint{Url: "https://ready.example.com"},
+				},
+			}},
+		},
+	}
+
+	refreshFunc := buildRefreshFunc(mock)
+
+	// First two calls return pending
+	_, state, err := refreshFunc()
+	require.NoError(t, err)
+	assert.Equal(t, clusterWaitPending, state)
+
+	_, state, err = refreshFunc()
+	require.NoError(t, err)
+	assert.Equal(t, clusterWaitPending, state)
+
+	// Third call returns ready
+	result, state, err := refreshFunc()
+	require.NoError(t, err)
+	assert.Equal(t, clusterWaitReady, state)
+	cluster := result.(*qcCluster.Cluster)
+	assert.Equal(t, "https://ready.example.com", cluster.GetState().GetEndpoint().GetUrl())
+	assert.Equal(t, 3, mock.callCount)
+}


### PR DESCRIPTION
## Summary
After `CreateCluster`, poll `GetCluster` using `retry.StateChangeConf` until the endpoint URL is populated before storing state. This ensures the `url` output is available on the first `terraform apply` without needing a second run.

Closes #169

## Changes
- Use `retry.StateChangeConf` for idiomatic Terraform polling (consistent with AWS/GCP/Azure providers)
- Add `schema.ResourceTimeout` so users can configure the create timeout via `timeouts { create = "30m" }` in HCL (default 20m)
- Add `clusterEndpointRefreshFunc` that returns `ready` when URL is populated, `waiting` while provisioning
- Fail fast on `CLUSTER_PHASE_FAILED_TO_CREATE` instead of waiting the full timeout
- Flatten state from the final `GetCluster` response (after URL is available) instead of the `CreateCluster` response
- Add acceptance test check for `url` being set on first apply

## Verification
Built the provider locally and created two clusters on `grpc.development-cloud.qdrant.io`, confirming the URL is populated on first apply:
```
qdrant-cloud_accounts_cluster.url_test: Creating...
qdrant-cloud_accounts_cluster.url_test: Still creating... [10s elapsed]
qdrant-cloud_accounts_cluster.url_test: Creation complete after 13s

cluster_url = "https://80b9c0ff-...eu-central-1-1.aws.development-cloud.qdrant.io"
```

## Test plan
- [x] Unit tests for refresh function: returns ready when URL present, returns pending when empty, fail-fast on FAILED_TO_CREATE, propagates API errors, eventual success after multiple polls
- [x] All existing unit tests pass
- [x] `golangci-lint` — 0 issues
- [x] `gofmt` — clean
- [x] End-to-end verified twice with real cluster creation on dev cloud