### PR TITLE
fix: sync role_ids from API in Read to detect drift

### DIFF
--- a/docs/resources/accounts_user_roles.md
+++ b/docs/resources/accounts_user_roles.md
@@ -3,7 +3,7 @@
 page_title: "qdrant-cloud_accounts_user_roles Resource - terraform-provider-qdrant-cloud"
 subcategory: ""
 description: |-
-  User Roles resource for Qdrant Cloud (non-authoritative add-only per user; user specified by email).
+  User Roles resource for Qdrant Cloud. Manages roles for a single user (by email). Detects drift: roles removed outside Terraform are re-added on apply. Roles added outside Terraform are ignored (non-authoritative).
 ---
 
 # qdrant-cloud_accounts_user_roles (Resource)
@@ -80,19 +80,24 @@ This resource manages **role assignments** for a single user (identified by emai
 
 ### Behavior
 
-- **Create**: Assigns the listed `role_ids` to the user (resolved by email).  
-- **Update**: Adds newly specified roles; does not revoke existing roles outside of Terraform’s management.  
-- **Delete**: Revokes only the roles listed in this resource (unless `keep_on_destroy = true`).  
+- **Create**: Assigns the listed `role_ids` to the user (resolved by email).
+- **Read**: Fetches actual role assignments from the API. Detects drift for managed roles (roles removed outside Terraform are re-added on next apply). Roles added outside Terraform are ignored.
+- **Update**: Adds newly specified roles and revokes roles that were previously managed but removed from config.
+- **Delete**: Revokes only the roles listed in this resource (unless `keep_on_destroy = true`).
 - **Import**: Not supported — reconciliation happens automatically during creation.
 
 ### Attributes
 
-- `user_id` — Resolved unique identifier (UUID) for the specified user.  
-- `role_ids` — Set of role IDs managed by this resource.  
-- `keep_on_destroy` — Prevents revocation of managed roles during destroy (boolean).  
+- `user_id` — Resolved unique identifier (UUID) for the specified user.
+- `role_ids` — Set of role IDs managed by this resource.
+- `keep_on_destroy` — Prevents revocation of managed roles during destroy (boolean).
+
+### Drift Detection
+
+The resource detects when managed roles are removed outside of Terraform (e.g., via the console). On the next `terraform plan`, the removed roles appear as a diff and are re-added on `apply`. Roles added outside of Terraform are not affected.
 
 ### Important Notes
 
-- This resource is **non-authoritative** — it only manages the roles explicitly listed in `role_ids`.  
-- The user must already exist in the account.  
+- This resource is **non-authoritative** — it only manages the roles explicitly listed in `role_ids`. Externally added roles are not removed.
+- The user must already exist in the account.
 - On destroy, roles in `role_ids` are revoked unless `keep_on_destroy` is set to `true`.

--- a/qdrant/resource_accounts_user_roles.go
+++ b/qdrant/resource_accounts_user_roles.go
@@ -21,7 +21,7 @@ import (
 // On delete, it revokes only the roles managed by this resource unless keep_on_destroy is true.
 func resourceAccountsUserRoles() *schema.Resource {
 	return &schema.Resource{
-		Description:   "User Roles resource for Qdrant Cloud (non-authoritative add-only per user; user specified by email).",
+		Description:   "User Roles resource for Qdrant Cloud. Manages roles for a single user (by email). Detects drift: roles removed outside Terraform are re-added on apply. Roles added outside Terraform are ignored (non-authoritative).",
 		CreateContext: resourceUserRolesCreate,
 		ReadContext:   resourceUserRolesRead,
 		UpdateContext: resourceUserRolesUpdate,

--- a/qdrant/resource_accounts_user_roles.go
+++ b/qdrant/resource_accounts_user_roles.go
@@ -90,8 +90,11 @@ func resourceUserRolesCreate(ctx context.Context, d *schema.ResourceData, m inte
 	return resourceUserRolesRead(ctx, d, m)
 }
 
-// resourceUserRolesRead fetches the user identifier and ensures the canonical ID is set.
-// It intentionally does not write role_ids to avoid removing externally managed roles.
+// resourceUserRolesRead fetches the current role assignments from the API and
+// reconciles them with the desired state. It updates role_ids in state to the
+// intersection of desired and actual roles, so that externally removed roles
+// are detected as drift while externally added roles are ignored (preserving
+// non-authoritative behavior).
 // ctx: Context to carry deadlines, cancellation signals, and other request-scoped values across API calls.
 // d: Resource data which is used to manage the state of the resource.
 // m: The interface where the configured client is passed.
@@ -99,10 +102,15 @@ func resourceUserRolesCreate(ctx context.Context, d *schema.ResourceData, m inte
 func resourceUserRolesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	const op = "error reading user roles"
 
-	acctClient, clientCtx, diags := getServiceClient(ctx, m, qca.NewAccountServiceClient)
+	// Get a client connection and context
+	apiClientConn, clientCtx, diags := getClientConnection(ctx, m)
 	if diags.HasError() {
 		return diags
 	}
+	// Get clients
+	iamClient := qci.NewIAMServiceClient(apiClientConn)
+	acctClient := qca.NewAccountServiceClient(apiClientConn)
+
 	// Get account ID as UUID
 	accountUUID, err := getAccountUUID(d, m)
 	if err != nil {
@@ -129,6 +137,27 @@ func resourceUserRolesRead(ctx context.Context, d *schema.ResourceData, m interf
 		d.SetId("")
 		return nil
 	}
+
+	// Read actual roles from API
+	current, _, err := listUserRoleIDs(clientCtx, iamClient, accountID, userID)
+	if err != nil {
+		// If user no longer exists, clear state
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("%s: %w", op, err))
+	}
+
+	// Update role_ids in state to the intersection of desired and actual roles.
+	// - If a managed role was removed externally → it drops out of the intersection
+	//   → Terraform detects the diff and plans to re-add it.
+	// - If an unmanaged role was added externally → it is not in desired
+	//   → it is excluded from the intersection → state is unchanged → no diff.
+	// This preserves non-authoritative behavior while enabling drift detection.
+	desired := setToStringSlice(d.Get(userRolesRoleIdsFieldName))
+	managed := intersectStrings(current, desired)
+	_ = d.Set(userRolesRoleIdsFieldName, managed)
 
 	// Set canonical ID
 	d.SetId(fmt.Sprintf("%s/%s", accountID, userID))

--- a/templates/resources/accounts_user_roles.md.tmpl
+++ b/templates/resources/accounts_user_roles.md.tmpl
@@ -22,19 +22,24 @@ This resource manages **role assignments** for a single user (identified by emai
 
 ### Behavior
 
-- **Create**: Assigns the listed `role_ids` to the user (resolved by email).  
-- **Update**: Adds newly specified roles; does not revoke existing roles outside of Terraform’s management.  
-- **Delete**: Revokes only the roles listed in this resource (unless `keep_on_destroy = true`).  
+- **Create**: Assigns the listed `role_ids` to the user (resolved by email).
+- **Read**: Fetches actual role assignments from the API. Detects drift for managed roles (roles removed outside Terraform are re-added on next apply). Roles added outside Terraform are ignored.
+- **Update**: Adds newly specified roles and revokes roles that were previously managed but removed from config.
+- **Delete**: Revokes only the roles listed in this resource (unless `keep_on_destroy = true`).
 - **Import**: Not supported — reconciliation happens automatically during creation.
 
 ### Attributes
 
-- `user_id` — Resolved unique identifier (UUID) for the specified user.  
-- `role_ids` — Set of role IDs managed by this resource.  
-- `keep_on_destroy` — Prevents revocation of managed roles during destroy (boolean).  
+- `user_id` — Resolved unique identifier (UUID) for the specified user.
+- `role_ids` — Set of role IDs managed by this resource.
+- `keep_on_destroy` — Prevents revocation of managed roles during destroy (boolean).
+
+### Drift Detection
+
+The resource detects when managed roles are removed outside of Terraform (e.g., via the console). On the next `terraform plan`, the removed roles appear as a diff and are re-added on `apply`. Roles added outside of Terraform are not affected.
 
 ### Important Notes
 
-- This resource is **non-authoritative** — it only manages the roles explicitly listed in `role_ids`.  
-- The user must already exist in the account.  
+- This resource is **non-authoritative** — it only manages the roles explicitly listed in `role_ids`. Externally added roles are not removed.
+- The user must already exist in the account.
 - On destroy, roles in `role_ids` are revoked unless `keep_on_destroy` is set to `true`.


### PR DESCRIPTION
## Summary

The `resourceUserRolesRead` function did not fetch actual role assignments from the API. It only resolved the user ID and set the canonical ID. This meant that roles removed outside of Terraform (e.g., via the console) were never detected by `terraform plan`.

## Change

`Read` now calls `listUserRoleIDs` (which already existed and was used by Create/Update/Delete) and updates `role_ids` in state to the **intersection** of desired and actual roles:

- **Role removed externally** → drops out of the intersection → Terraform detects diff → re-adds on apply
- **Role added externally** → not in desired set → excluded from intersection → no diff (non-authoritative preserved)

This is a backwards-compatible change. Existing users who rely on non-authoritative behavior are unaffected — externally added roles continue to be ignored.

## Testing

- All existing unit tests pass (`make test.unit`)
- Linter passes (`make lint`, 0 issues)
- Acceptance tests not run locally (require API credentials), but the change only affects the Read path and uses existing helper functions (`listUserRoleIDs`, `intersectStrings`, `setToStringSlice`)

Fixes #197