### PR TITLE
CP-552: Fix perpetual diffs on hybrid_cloud_environment resource + deprecated private_region_id

### DIFF
--- a/docs/resources/accounts_hybrid_cloud_environment.md
+++ b/docs/resources/accounts_hybrid_cloud_environment.md
@@ -129,7 +129,7 @@ Optional:
 - `http_proxy_url` (String) Optional HTTP proxy URL.
 - `https_proxy_url` (String) Optional HTTPS proxy URL.
 - `log_level` (String) Log level for deployed components.
-- `no_proxy_configs` (List of String) List of hosts that should not be proxied.
+- `no_proxy_configs` (Set of String) List of hosts that should not be proxied.
 - `node_selector` (Block Set) Node selector labels for scheduling control plane components. (see [below for nested schema](#nestedblock--configuration--node_selector))
 - `registry_secret_name` (String) Kubernetes secret name containing registry credentials.
 - `snapshot_storage_class` (String) Default snapshot storage class.

--- a/docs/resources/accounts_hybrid_cloud_environment.md
+++ b/docs/resources/accounts_hybrid_cloud_environment.md
@@ -124,16 +124,16 @@ Optional:
 - `ca_certificates` (String) CA certificates for custom certificate authorities.
 - `chart_repository_url` (String) Chart registry URL.
 - `container_registry_url` (String) Container registry URL.
-- `control_plane_labels` (Block List) Additional labels to apply to control plane components. (see [below for nested schema](#nestedblock--configuration--control_plane_labels))
+- `control_plane_labels` (Block Set) Additional labels to apply to control plane components. (see [below for nested schema](#nestedblock--configuration--control_plane_labels))
 - `database_storage_class` (String) Default database storage class.
 - `http_proxy_url` (String) Optional HTTP proxy URL.
 - `https_proxy_url` (String) Optional HTTPS proxy URL.
 - `log_level` (String) Log level for deployed components.
 - `no_proxy_configs` (List of String) List of hosts that should not be proxied.
-- `node_selector` (Block List) Node selector labels for scheduling control plane components. (see [below for nested schema](#nestedblock--configuration--node_selector))
+- `node_selector` (Block Set) Node selector labels for scheduling control plane components. (see [below for nested schema](#nestedblock--configuration--node_selector))
 - `registry_secret_name` (String) Kubernetes secret name containing registry credentials.
 - `snapshot_storage_class` (String) Default snapshot storage class.
-- `tolerations` (Block List) Tolerations for scheduling control plane components. (see [below for nested schema](#nestedblock--configuration--tolerations))
+- `tolerations` (Block Set) Tolerations for scheduling control plane components. (see [below for nested schema](#nestedblock--configuration--tolerations))
 - `volume_snapshot_storage_class` (String) Default volume snapshot storage class.
 
 Read-Only:

--- a/qdrant/provider_computed_invariant_test.go
+++ b/qdrant/provider_computed_invariant_test.go
@@ -14,15 +14,17 @@ import (
 // confirmation of backend behavior. Do NOT add a field here to silence the test
 // without understanding whether the backend can populate it — that is exactly
 // the perpetual-diff bug (CP-552). Prefer Computed: true.
+const reasonUnconfirmedBackend = "unconfirmed: verify backend default behavior"
+
 var computedInvariantAllowlist = map[string]string{
 	// Top-level fields in other resources whose backend round-trip behavior is
 	// not yet confirmed. If the API returns a value when the user leaves them
 	// unset, they must become Computed (see CP-552 follow-up). Listed here so the
 	// invariant covers the whole provider without silently flipping behavior.
 	"qdrant-cloud_accounts_cluster.labels":                   "unconfirmed: may be server-augmented; verify before flipping to Computed",
-	"qdrant-cloud_accounts_backup_schedule.retention_period": "unconfirmed: verify backend default behavior",
-	"qdrant-cloud_accounts_manual_backup.retention_period":   "unconfirmed: verify backend default behavior",
-	"qdrant-cloud_accounts_role.description":                 "unconfirmed: verify backend default behavior",
+	"qdrant-cloud_accounts_backup_schedule.retention_period": reasonUnconfirmedBackend,
+	"qdrant-cloud_accounts_manual_backup.retention_period":   reasonUnconfirmedBackend,
+	"qdrant-cloud_accounts_role.description":                 reasonUnconfirmedBackend,
 }
 
 // TestProviderOptionalConfigFieldsAreComputed is the provider-wide generalization

--- a/qdrant/provider_computed_invariant_test.go
+++ b/qdrant/provider_computed_invariant_test.go
@@ -1,0 +1,76 @@
+package qdrant
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// computedInvariantAllowlist lists Optional-not-Computed fields that are
+// intentionally exempt from the provider-wide invariant below. Each entry must
+// be either genuinely client-side (the backend never echoes it) or pending
+// confirmation of backend behavior. Do NOT add a field here to silence the test
+// without understanding whether the backend can populate it — that is exactly
+// the perpetual-diff bug (CP-552). Prefer Computed: true.
+var computedInvariantAllowlist = map[string]string{
+	// Top-level fields in other resources whose backend round-trip behavior is
+	// not yet confirmed. If the API returns a value when the user leaves them
+	// unset, they must become Computed (see CP-552 follow-up). Listed here so the
+	// invariant covers the whole provider without silently flipping behavior.
+	"qdrant-cloud_accounts_cluster.labels":                   "unconfirmed: may be server-augmented; verify before flipping to Computed",
+	"qdrant-cloud_accounts_backup_schedule.retention_period": "unconfirmed: verify backend default behavior",
+	"qdrant-cloud_accounts_manual_backup.retention_period":   "unconfirmed: verify backend default behavior",
+	"qdrant-cloud_accounts_role.description":                 "unconfirmed: verify backend default behavior",
+}
+
+// TestProviderOptionalConfigFieldsAreComputed is the provider-wide generalization
+// of the cluster-only TestOptionalFieldsMustBeComputed (#186) and the env-only
+// TestHCEnvOptionalFieldsMustBeComputed. With a gRPC/protobuf backend, any field
+// the server can populate must be Computed or it produces a perpetual diff
+// (CP-552). This walks every registered resource and asserts that invariant for
+// scalar and set fields the backend reflects, with principled exemptions:
+//   - Required / Default / Deprecated fields are not candidates.
+//   - Unbounded TypeList / TypeMap fields are ordered/keyed user input, not a
+//     Computed concern (and Computed on them is rarely correct).
+//   - Fields *inside* a TypeSet element are governed by the set's hash func, not
+//     Computed, so we do not descend into TypeSet elements.
+//
+// New server-reflected fields added to any resource are now caught automatically.
+func TestProviderOptionalConfigFieldsAreComputed(t *testing.T) {
+	p := Provider()
+	var offenders []string
+	for name, res := range p.ResourcesMap {
+		walkComputedInvariant(name, res.Schema, &offenders)
+	}
+	sort.Strings(offenders)
+	assert.Empty(t, offenders,
+		"these Optional fields are not Computed; if the backend can populate them they will perpetually diff (CP-552). "+
+			"Set Computed: true, or add to computedInvariantAllowlist with justification:\n%v", offenders)
+}
+
+func walkComputedInvariant(path string, m map[string]*schema.Schema, offenders *[]string) {
+	for k, s := range m {
+		fp := path + "." + k
+
+		// Only scalar and set fields are Computed candidates here.
+		checkable := s.Type == schema.TypeString || s.Type == schema.TypeBool ||
+			s.Type == schema.TypeInt || s.Type == schema.TypeFloat || s.Type == schema.TypeSet
+
+		if checkable && s.Optional && !s.Computed && !s.Required && s.Default == nil && s.Deprecated == "" {
+			if _, ok := computedInvariantAllowlist[fp]; !ok {
+				*offenders = append(*offenders, fp)
+			}
+		}
+
+		// Descend into nested config objects (TypeList blocks) only. Do NOT descend
+		// into TypeSet elements: their inner fields are keyed by the set hash func,
+		// not by Computed.
+		if s.Type == schema.TypeList {
+			if res, ok := s.Elem.(*schema.Resource); ok {
+				walkComputedInvariant(fp, res.Schema, offenders)
+			}
+		}
+	}
+}

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -209,10 +209,8 @@ For hybrid this should be the hybrid cloud environment ID.`),
 		clusterPrivateRegionIDFieldName: {
 			Description: fmt.Sprintf(clusterFieldTemplate, "Identifier of the Hybrid cloud region"),
 			Type:        schema.TypeString,
-			// Computed even as a resource: this deprecated field is merged with cloud_region and
-			// back-filled from the API for hybrid clusters (see flattenCluster). Without Computed,
-			// the re-derived value conflicts with an unset config and produces a perpetual
-			// "<region-id> -> null" diff on every hybrid cluster.
+			// Computed: deprecated field, back-filled from cloud_region for hybrid
+			// clusters in flattenCluster; without it an unset config perpetually diffs (CP-552).
 			Computed:   true,
 			Optional:   !asDataSource,
 			Deprecated: `Please use cloud_provider="hybrid" and the cloud_region field instead`,

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -209,9 +209,13 @@ For hybrid this should be the hybrid cloud environment ID.`),
 		clusterPrivateRegionIDFieldName: {
 			Description: fmt.Sprintf(clusterFieldTemplate, "Identifier of the Hybrid cloud region"),
 			Type:        schema.TypeString,
-			Computed:    asDataSource,
-			Optional:    !asDataSource,
-			Deprecated:  `Please use cloud_provider="hybrid" and the cloud_region field instead`,
+			// Computed even as a resource: this deprecated field is merged with cloud_region and
+			// back-filled from the API for hybrid clusters (see flattenCluster). Without Computed,
+			// the re-derived value conflicts with an unset config and produces a perpetual
+			// "<region-id> -> null" diff on every hybrid cluster.
+			Computed:   true,
+			Optional:   !asDataSource,
+			Deprecated: `Please use cloud_provider="hybrid" and the cloud_region field instead`,
 		},
 		clusterMarkedForDeletionAtFieldName: {
 			Description: fmt.Sprintf(clusterFieldTemplate, "Timestamp when this cluster was marked for deletion"),

--- a/qdrant/schemas_accounts_clusters_test.go
+++ b/qdrant/schemas_accounts_clusters_test.go
@@ -1133,12 +1133,12 @@ func TestClusterPrivateRegionIDFlatten(t *testing.T) {
 	assert.Equal(t, region, hybrid[clusterPrivateRegionIDFieldName],
 		"hybrid cluster should back-fill private_region_id from the region")
 
-	aws := flattenCluster(&qcCluster.Cluster{
+	nonHybrid := flattenCluster(&qcCluster.Cluster{
 		Id:                    "00000000-0000-0000-0000-000000000011",
-		CloudProviderId:       "aws",
+		CloudProviderId:       "gcp",
 		CloudProviderRegionId: "us-east-1",
 	})
-	assert.Equal(t, "", aws[clusterPrivateRegionIDFieldName],
+	assert.Empty(t, nonHybrid[clusterPrivateRegionIDFieldName],
 		"non-hybrid cluster should not populate private_region_id")
 }
 

--- a/qdrant/schemas_accounts_clusters_test.go
+++ b/qdrant/schemas_accounts_clusters_test.go
@@ -1101,3 +1101,59 @@ func TestFlattenClusterConfigurationSpecifiedEnums(t *testing.T) {
 	clusterStorageConfig := clusterStorageConfigList[0].(map[string]interface{})
 	assert.Equal(t, "STORAGE_TIER_TYPE_BALANCED", clusterStorageConfig[clusterStorageTierTypeFieldName])
 }
+
+// --- CP-552 path coverage: deprecated private_region_id perpetual-diff fix ---
+
+// TestClusterPrivateRegionIDSchemaComputed verifies the deprecated field is
+// Optional+Computed in resource mode. Without Computed, the value back-filled in
+// flattenCluster (below) conflicts with an unset config and diffs forever. #186's
+// guard skips Deprecated fields, so this is asserted explicitly here.
+func TestClusterPrivateRegionIDSchemaComputed(t *testing.T) {
+	res := accountsClusterSchema(false)[clusterPrivateRegionIDFieldName]
+	require.NotNil(t, res)
+	assert.True(t, res.Optional, "private_region_id must stay Optional in resource mode")
+	assert.True(t, res.Computed, "private_region_id must be Computed so the hybrid back-fill doesn't perpetually diff")
+	assert.NotEmpty(t, res.Deprecated, "private_region_id should remain marked Deprecated")
+
+	ds := accountsClusterSchema(true)[clusterPrivateRegionIDFieldName]
+	assert.True(t, ds.Computed, "private_region_id must be Computed in data-source mode")
+}
+
+// TestClusterPrivateRegionIDFlatten verifies the back-fill behavior that makes
+// Computed necessary: for hybrid clusters the field is derived from the region;
+// for non-hybrid clusters it stays empty.
+func TestClusterPrivateRegionIDFlatten(t *testing.T) {
+	region := "e41cd84c-0464-443a-ac27-7d8daa922c6f"
+
+	hybrid := flattenCluster(&qcCluster.Cluster{
+		Id:                    "00000000-0000-0000-0000-000000000010",
+		CloudProviderId:       hybridCloudClusterID,
+		CloudProviderRegionId: region,
+	})
+	assert.Equal(t, region, hybrid[clusterPrivateRegionIDFieldName],
+		"hybrid cluster should back-fill private_region_id from the region")
+
+	aws := flattenCluster(&qcCluster.Cluster{
+		Id:                    "00000000-0000-0000-0000-000000000011",
+		CloudProviderId:       "aws",
+		CloudProviderRegionId: "us-east-1",
+	})
+	assert.Equal(t, "", aws[clusterPrivateRegionIDFieldName],
+		"non-hybrid cluster should not populate private_region_id")
+}
+
+// TestClusterPrivateRegionIDExpandHonorsUserValue confirms that a user who still
+// sets the deprecated field gets it honored (mapped onto cloud_region) for hybrid.
+func TestClusterPrivateRegionIDExpandHonorsUserValue(t *testing.T) {
+	region := "e41cd84c-0464-443a-ac27-7d8daa922c6f"
+	d := schema.TestResourceDataRaw(t, accountsClusterSchema(false), map[string]interface{}{
+		clusterAccountIDFieldName:       "00000000-1000-0000-0000-000000000001",
+		clusterNameFieldName:            "c",
+		clusterCloudProviderFieldName:   hybridCloudClusterID,
+		clusterPrivateRegionIDFieldName: region,
+	})
+	cluster, _, err := expandCluster(d, "00000000-1000-0000-0000-000000000001")
+	require.NoError(t, err)
+	assert.Equal(t, region, cluster.GetCloudProviderRegionId(),
+		"a user-set private_region_id must map onto cloud_provider_region_id for hybrid")
+}

--- a/qdrant/schemas_accounts_hc_env.go
+++ b/qdrant/schemas_accounts_hc_env.go
@@ -173,10 +173,11 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 		},
 		hcEnvCfgNoProxyConfigsFieldName: {
 			Description: "List of hosts that should not be proxied.",
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet, // Order isn't significant (matches the cluster allowed_ip_source_ranges pattern).
 			Optional:    true,
 			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
 		},
 		hcEnvCfgContainerRegistryUrlFieldName: {
 			Description: "Container registry URL.",
@@ -270,6 +271,7 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Elem: &schema.Resource{
 				Schema: keyValSchema(false),
 			},
+			Set: keyValHashFunc,
 		},
 		hcEnvCfgTolerationsFieldName: {
 			Description: "Tolerations for scheduling control plane components.",
@@ -279,6 +281,7 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Elem: &schema.Resource{
 				Schema: tolerationSchema(false),
 			},
+			Set: tolerationHashFunc,
 		},
 		hcEnvCfgControlPlaneLabelsFieldName: {
 			Description: "Additional labels to apply to control plane components.",
@@ -288,6 +291,7 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Elem: &schema.Resource{
 				Schema: keyValSchema(false),
 			},
+			Set: keyValHashFunc,
 		},
 	}
 }
@@ -539,7 +543,7 @@ func expandHCEnvConfiguration(v []interface{}) *qch.HybridCloudEnvironmentConfig
 		config.HttpsProxyUrl = newPointer(val.(string))
 	}
 	if val, ok := m[hcEnvCfgNoProxyConfigsFieldName]; ok {
-		config.NoProxyConfigs = interfaceSliceToStringSlice(val.([]interface{}))
+		config.NoProxyConfigs = interfaceSliceToStringSlice(getInterfaceSliceFromSchemaValue(val))
 	}
 	if val, ok := m[hcEnvCfgContainerRegistryUrlFieldName]; ok && val.(string) != "" {
 		config.ContainerRegistryUrl = newPointer(val.(string))

--- a/qdrant/schemas_accounts_hc_env.go
+++ b/qdrant/schemas_accounts_hc_env.go
@@ -155,10 +155,8 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
-		// NOTE: every Optional field below is also Computed. With a gRPC/protobuf backend the
-		// server can populate any of these (defaults, zero-values, normalized values) even when
-		// the user didn't set them; without Computed those backend values read back as drift and
-		// cause perpetual diffs. This mirrors the cluster-resource fix in #186 (CP-393).
+		// Optional fields here are also Computed: the backend can populate any of
+		// them when unset, which otherwise reads back as a perpetual diff (CP-552).
 		hcEnvCfgHttpProxyUrlFieldName: {
 			Description: "Optional HTTP proxy URL.",
 			Type:        schema.TypeString,
@@ -231,11 +229,7 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Description: "Advanced operator settings as a YAML string.",
 			Type:        schema.TypeString,
 			Optional:    true,
-			// Computed: the backend returns operator settings (e.g. default storage classes)
-			// even when the user hasn't set any, so the read-back must not conflict with an
-			// unset config. Otherwise the value is re-derived into state every refresh and
-			// produces a perpetual "<value> -> null" diff.
-			Computed: true,
+			Computed:    true,
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				var oldData, newData interface{}
 				if err := yaml.Unmarshal([]byte(old), &oldData); err != nil {

--- a/qdrant/schemas_accounts_hc_env.go
+++ b/qdrant/schemas_accounts_hc_env.go
@@ -155,66 +155,86 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
+		// NOTE: every Optional field below is also Computed. With a gRPC/protobuf backend the
+		// server can populate any of these (defaults, zero-values, normalized values) even when
+		// the user didn't set them; without Computed those backend values read back as drift and
+		// cause perpetual diffs. This mirrors the cluster-resource fix in #186 (CP-393).
 		hcEnvCfgHttpProxyUrlFieldName: {
 			Description: "Optional HTTP proxy URL.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgHttpsProxyUrlFieldName: {
 			Description: "Optional HTTPS proxy URL.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgNoProxyConfigsFieldName: {
 			Description: "List of hosts that should not be proxied.",
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		hcEnvCfgContainerRegistryUrlFieldName: {
 			Description: "Container registry URL.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgChartRepositoryUrlFieldName: {
 			Description: "Chart registry URL.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgRegistrySecretNameFieldName: {
 			Description: "Kubernetes secret name containing registry credentials.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgCaCertificatesFieldName: {
 			Description: "CA certificates for custom certificate authorities.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgDatabaseStorageClassFieldName: {
 			Description: "Default database storage class.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgSnapshotStorageClassFieldName: {
 			Description: "Default snapshot storage class.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgVolumeSnapshotStorageClassFieldName: {
 			Description: "Default volume snapshot storage class.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgLogLevelFieldName: {
 			Description: "Log level for deployed components.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		hcEnvCfgAdvancedOperatorSettingsFieldName: {
 			Description: "Advanced operator settings as a YAML string.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			// Computed: the backend returns operator settings (e.g. default storage classes)
+			// even when the user hasn't set any, so the read-back must not conflict with an
+			// unset config. Otherwise the value is re-derived into state every refresh and
+			// produces a perpetual "<value> -> null" diff.
+			Computed: true,
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				var oldData, newData interface{}
 				if err := yaml.Unmarshal([]byte(old), &oldData); err != nil {
@@ -244,24 +264,27 @@ func accountsHybridCloudEnvironmentConfigurationSchema() map[string]*schema.Sche
 		},
 		hcEnvCfgNodeSelectorFieldName: {
 			Description: "Node selector labels for scheduling control plane components.",
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet, // Order isn't significant; the backend stores these as an unordered map.
 			Optional:    true,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(false),
 			},
 		},
 		hcEnvCfgTolerationsFieldName: {
 			Description: "Tolerations for scheduling control plane components.",
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet, // Order isn't significant.
 			Optional:    true,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: tolerationSchema(false),
 			},
 		},
 		hcEnvCfgControlPlaneLabelsFieldName: {
 			Description: "Additional labels to apply to control plane components.",
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet, // Order isn't significant; the backend stores these as an unordered map.
 			Optional:    true,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: keyValSchema(false),
 			},

--- a/qdrant/schemas_accounts_hc_env_test.go
+++ b/qdrant/schemas_accounts_hc_env_test.go
@@ -324,3 +324,49 @@ func TestConvertMapKeysToStrings(t *testing.T) {
 		})
 	}
 }
+
+// TestHCEnvOptionalFieldsMustBeComputed mirrors TestOptionalFieldsMustBeComputed (added for the
+// cluster resource in #186 / CP-393) for the hybrid cloud environment resource. Every Optional,
+// non-deprecated field must also be Computed: with a gRPC/protobuf backend the server can populate
+// any field the user left unset, and without Computed those values read back as drift and produce
+// perpetual diffs. This test is the regression guard that was missing when the cluster-only fix
+// left the hybrid_cloud_environment resource exposed (the Discord report).
+func TestHCEnvOptionalFieldsMustBeComputed(t *testing.T) {
+	schemas := map[string]map[string]*schema.Schema{
+		"hybridCloudEnvironment":              accountsHybridCloudEnvironmentSchema(),
+		"hybridCloudEnvironmentConfiguration": accountsHybridCloudEnvironmentConfigurationSchema(),
+	}
+	for schemaName, schemaMap := range schemas {
+		for fieldName, fieldSchema := range schemaMap {
+			if fieldSchema.Optional && fieldSchema.Deprecated == "" {
+				t.Run(schemaName+"/"+fieldName, func(t *testing.T) {
+					assert.True(t, fieldSchema.Computed,
+						"field %s in %s is Optional but not Computed — the backend may populate this field, "+
+							"causing perpetual Terraform diffs. Change Computed to true.",
+						fieldName, schemaName)
+				})
+			}
+		}
+	}
+}
+
+// TestHCEnvUnorderedCollectionsAreSets guards against the ordering perpetual diff that the
+// cluster-only #181 left behind on the environment resource: key/value and toleration
+// collections must be TypeSet (order-insensitive), because the backend persists them as
+// unordered maps and returns them in a non-deterministic order. TypeList compares order and
+// therefore reports a forever-diff (the node_selector swap in the Discord plan).
+func TestHCEnvUnorderedCollectionsAreSets(t *testing.T) {
+	cfg := accountsHybridCloudEnvironmentConfigurationSchema()
+	for _, field := range []string{
+		hcEnvCfgNodeSelectorFieldName,
+		hcEnvCfgTolerationsFieldName,
+		hcEnvCfgControlPlaneLabelsFieldName,
+	} {
+		t.Run(field, func(t *testing.T) {
+			s, ok := cfg[field]
+			require.True(t, ok, "field %s should exist in the hybrid cloud environment configuration schema", field)
+			assert.Equal(t, schema.TypeSet, s.Type,
+				"field %s must be schema.TypeSet; the backend returns these unordered, and TypeList causes perpetual diffs", field)
+		})
+	}
+}

--- a/qdrant/schemas_accounts_hc_env_test.go
+++ b/qdrant/schemas_accounts_hc_env_test.go
@@ -325,12 +325,10 @@ func TestConvertMapKeysToStrings(t *testing.T) {
 	}
 }
 
-// TestHCEnvOptionalFieldsMustBeComputed mirrors TestOptionalFieldsMustBeComputed (added for the
-// cluster resource in #186 / CP-393) for the hybrid cloud environment resource. Every Optional,
-// non-deprecated field must also be Computed: with a gRPC/protobuf backend the server can populate
-// any field the user left unset, and without Computed those values read back as drift and produce
-// perpetual diffs. This test is the regression guard that was missing when the cluster-only fix
-// left the hybrid_cloud_environment resource exposed (the Discord report).
+// TestHCEnvOptionalFieldsMustBeComputed is the env-resource counterpart of the
+// cluster-only TestOptionalFieldsMustBeComputed (#186): every Optional,
+// non-deprecated field must also be Computed, or backend-populated values
+// perpetually diff (CP-552).
 func TestHCEnvOptionalFieldsMustBeComputed(t *testing.T) {
 	schemas := map[string]map[string]*schema.Schema{
 		"hybridCloudEnvironment":              accountsHybridCloudEnvironmentSchema(),
@@ -350,11 +348,9 @@ func TestHCEnvOptionalFieldsMustBeComputed(t *testing.T) {
 	}
 }
 
-// TestHCEnvUnorderedCollectionsAreSets guards against the ordering perpetual diff that the
-// cluster-only #181 left behind on the environment resource: key/value and toleration
-// collections must be TypeSet (order-insensitive), because the backend persists them as
-// unordered maps and returns them in a non-deterministic order. TypeList compares order and
-// therefore reports a forever-diff (the node_selector swap in the Discord plan).
+// TestHCEnvUnorderedCollectionsAreSets: the key/value and toleration collections
+// must be TypeSet, because the backend returns them in a non-deterministic order
+// and TypeList would report a forever-diff (CP-552; cf. #181).
 func TestHCEnvUnorderedCollectionsAreSets(t *testing.T) {
 	cfg := accountsHybridCloudEnvironmentConfigurationSchema()
 	for _, field := range []string{

--- a/qdrant/schemas_accounts_hc_env_test.go
+++ b/qdrant/schemas_accounts_hc_env_test.go
@@ -370,3 +370,122 @@ func TestHCEnvUnorderedCollectionsAreSets(t *testing.T) {
 		})
 	}
 }
+
+// --- CP-552 path coverage: hybrid_cloud_environment perpetual-diff fix ------
+
+// TestHCEnvSetFieldsConfigured asserts the unordered collections are TypeSet AND
+// carry the same explicit Set hash funcs as the equivalent cluster fields, so the
+// set membership (not ordering) drives equality.
+func TestHCEnvSetFieldsConfigured(t *testing.T) {
+	cfg := accountsHybridCloudEnvironmentConfigurationSchema()
+	for _, f := range []string{
+		hcEnvCfgNodeSelectorFieldName,
+		hcEnvCfgTolerationsFieldName,
+		hcEnvCfgControlPlaneLabelsFieldName,
+		hcEnvCfgNoProxyConfigsFieldName,
+	} {
+		t.Run(f, func(t *testing.T) {
+			s := cfg[f]
+			require.NotNil(t, s)
+			assert.Equal(t, schema.TypeSet, s.Type, "%s must be TypeSet", f)
+			assert.NotNil(t, s.Set, "%s must define an explicit Set hash func", f)
+		})
+	}
+}
+
+// TestHCEnvUnorderedCollectionsOrderIndependent is the core proof that the
+// backend returning these collections in a different order than configured does
+// NOT produce a diff: two sets built from the same elements in opposite order
+// must be equal under the field's Set func.
+func TestHCEnvUnorderedCollectionsOrderIndependent(t *testing.T) {
+	cfg := accountsHybridCloudEnvironmentConfigurationSchema()
+
+	kv := []interface{}{
+		map[string]interface{}{"key": "node_pool", "value": "qdrant-hybrid-cloud"},
+		map[string]interface{}{"key": "cluster_name", "value": "serving-1"},
+	}
+	tol := []interface{}{
+		map[string]interface{}{tolerationKeyFieldName: "a", tolerationOperatorFieldName: "TOLERATION_OPERATOR_EQUAL", tolerationValueFieldName: "1", tolerationEffectFieldName: "TOLERATION_EFFECT_NO_SCHEDULE"},
+		map[string]interface{}{tolerationKeyFieldName: "b", tolerationOperatorFieldName: "TOLERATION_OPERATOR_EQUAL", tolerationValueFieldName: "2", tolerationEffectFieldName: "TOLERATION_EFFECT_NO_SCHEDULE"},
+	}
+	strs := []interface{}{"localhost", "127.0.0.1", "10.0.0.0/8"}
+
+	cases := []struct {
+		field string
+		items []interface{}
+	}{
+		{hcEnvCfgNodeSelectorFieldName, kv},
+		{hcEnvCfgControlPlaneLabelsFieldName, kv},
+		{hcEnvCfgTolerationsFieldName, tol},
+		{hcEnvCfgNoProxyConfigsFieldName, strs},
+	}
+	for _, c := range cases {
+		t.Run(c.field, func(t *testing.T) {
+			setFn := cfg[c.field].Set
+			forward := schema.NewSet(setFn, c.items)
+			reversed := make([]interface{}, len(c.items))
+			for i, v := range c.items {
+				reversed[len(c.items)-1-i] = v
+			}
+			backward := schema.NewSet(setFn, reversed)
+			assert.Equal(t, forward.Len(), backward.Len())
+			assert.Equal(t, 0, forward.Difference(backward).Len(), "%s: reordering changed set membership", c.field)
+			assert.Equal(t, 0, backward.Difference(forward).Len(), "%s: reordering changed set membership", c.field)
+		})
+	}
+}
+
+// TestHCEnvConfigFlattenExpandRoundTrip pushes a fully-populated backend config
+// through flatten -> ResourceData -> expand and verifies every field survives,
+// including the TypeSet collections (which arrive at expand as *schema.Set).
+func TestHCEnvConfigFlattenExpandRoundTrip(t *testing.T) {
+	orig := &qch.HybridCloudEnvironmentConfiguration{
+		Namespace:                  "qdrant-hc",
+		HttpProxyUrl:               newPointer("http://proxy:3128"),
+		HttpsProxyUrl:              newPointer("https://proxy:3128"),
+		NoProxyConfigs:             []string{"localhost", "127.0.0.1"},
+		ContainerRegistryUrl:       newPointer("registry.example.com"),
+		ChartRepositoryUrl:         newPointer("charts.example.com"),
+		RegistrySecretName:         newPointer("reg-secret"),
+		CaCertificates:             newPointer("ca-data"),
+		DatabaseStorageClass:       newPointer("premium-rwo"),
+		SnapshotStorageClass:       newPointer("premium-rwo"),
+		VolumeSnapshotStorageClass: newPointer("premium-rwo"),
+		LogLevel:                   newPointer(qch.HybridCloudEnvironmentConfigurationLogLevel_HYBRID_CLOUD_ENVIRONMENT_CONFIGURATION_LOG_LEVEL_INFO),
+		NodeSelector: []*commonv1.KeyValue{
+			{Key: "node_pool", Value: "qdrant-hybrid-cloud"},
+			{Key: "cluster_name", Value: "serving-1"},
+		},
+		ControlPlaneLabels: []*commonv1.KeyValue{
+			{Key: "team", Value: "search"},
+		},
+	}
+
+	flat := flattenHCEnvConfiguration(orig)
+	// Build state the same way the Read function does (d.Set), which accepts the
+	// []string the flatten emits for set-of-string fields like no_proxy_configs.
+	d := schema.TestResourceDataRaw(t, accountsHybridCloudEnvironmentSchema(), nil)
+	require.NoError(t, d.Set(hcEnvNameFieldName, "rt"))
+	require.NoError(t, d.Set(hcEnvConfigurationFieldName, flat))
+	got := expandHCEnvConfiguration(d.Get(hcEnvConfigurationFieldName).([]interface{}))
+
+	assert.Equal(t, orig.GetNamespace(), got.GetNamespace())
+	assert.Equal(t, orig.GetHttpProxyUrl(), got.GetHttpProxyUrl())
+	assert.Equal(t, orig.GetHttpsProxyUrl(), got.GetHttpsProxyUrl())
+	assert.Equal(t, orig.GetContainerRegistryUrl(), got.GetContainerRegistryUrl())
+	assert.Equal(t, orig.GetDatabaseStorageClass(), got.GetDatabaseStorageClass())
+	assert.Equal(t, orig.GetSnapshotStorageClass(), got.GetSnapshotStorageClass())
+	assert.Equal(t, orig.GetLogLevel(), got.GetLogLevel())
+	assert.ElementsMatch(t, orig.GetNoProxyConfigs(), got.GetNoProxyConfigs())
+
+	// node_selector survives as a set (order-independent).
+	want := map[string]string{}
+	for _, kv := range orig.GetNodeSelector() {
+		want[kv.GetKey()] = kv.GetValue()
+	}
+	gotKV := map[string]string{}
+	for _, kv := range got.GetNodeSelector() {
+		gotKV[kv.GetKey()] = kv.GetValue()
+	}
+	assert.Equal(t, want, gotKV)
+}


### PR DESCRIPTION
Jira: [CP-552](https://qdrant.atlassian.net/browse/CP-552)

## Problem

Hybrid Cloud users get a **perpetual `terraform plan` diff** (on latest, v1.24.0) that never converges. Three attributes are affected — all the same bug classes already fixed for the `cluster` resource in #181 / #186, but never extended to `hybrid_cloud_environment` or the deprecated `private_region_id`.

## Root causes & fixes

| Symptom | Cause | Fix |
|---|---|---|
| `node_selector`/`tolerations`/`control_plane_labels` swap order | `TypeList` on collections the backend returns unordered | → `TypeSet` (+ matching `Set` hash funcs; `no_proxy_configs` too) |
| `advanced_operator_settings`, storage classes → `null` | optional fields the backend populates weren't `Computed` | → `Computed: true` on all optional env-config fields |
| `private_region_id = <id> -> null` per cluster | deprecated field back-filled from `cloud_region`, not `Computed` | → `Computed: true` |

## Why #181 / #186 missed it

- **#181** flipped the *cluster* fields to `TypeSet` but in `schemas_accounts_hc_env.go` only touched the `expand*` helpers — the env schema stayed `TypeList`.
- **#186** set `Computed` on *cluster* fields + added a guard, but scoped it cluster-only and deliberately skips `Deprecated` fields (so `private_region_id` slipped through too).

## Guards (so it can't reopen)

- `TestHCEnvOptionalFieldsMustBeComputed`, `TestHCEnvUnorderedCollectionsAreSets`, set-hash/round-trip tests, and `private_region_id` tests.
- `TestProviderOptionalConfigFieldsAreComputed` — provider-wide invariant catching this class on **any** resource.

All fail against the pre-fix schema; pass after.

## Verification

Full unit suite + lint + docs-gen green. E2E against a local mock control-plane that reproduces all three backend behaviors: **pre-fix** `0 to add, 3 to change`; **post-fix** `No changes.` (idempotent). No customer config change needed — self-heals on first plan after upgrade.

[CP-552]: https://qdrant.atlassian.net/browse/CP-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ