### PR TITLE
fix(clusters): validate toleration operator/effect and omit empty key/value

### DIFF
--- a/docs/resources/accounts_cluster.md
+++ b/docs/resources/accounts_cluster.md
@@ -345,9 +345,9 @@ Required:
 
 Optional:
 
-- `effect` (String)
+- `effect` (String) The toleration effect. Should be one of TOLERATION_EFFECT_NO_EXECUTE,TOLERATION_EFFECT_NO_SCHEDULE,TOLERATION_EFFECT_PREFER_NO_SCHEDULE.
 - `key` (String)
-- `operator` (String)
+- `operator` (String) The toleration operator. Should be one of TOLERATION_OPERATOR_EQUAL,TOLERATION_OPERATOR_EXISTS.
 - `toleration_seconds` (Number)
 - `value` (String)
 

--- a/docs/resources/accounts_hybrid_cloud_environment.md
+++ b/docs/resources/accounts_hybrid_cloud_environment.md
@@ -163,9 +163,9 @@ Required:
 
 Optional:
 
-- `effect` (String)
+- `effect` (String) The toleration effect. Should be one of TOLERATION_EFFECT_NO_EXECUTE,TOLERATION_EFFECT_NO_SCHEDULE,TOLERATION_EFFECT_PREFER_NO_SCHEDULE.
 - `key` (String)
-- `operator` (String)
+- `operator` (String) The toleration operator. Should be one of TOLERATION_OPERATOR_EQUAL,TOLERATION_OPERATOR_EXISTS.
 - `toleration_seconds` (Number)
 - `value` (String)
 

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -2,6 +2,7 @@ package qdrant
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -772,33 +773,67 @@ func keyValSchema(asDataSource bool) map[string]*schema.Schema {
 
 // tolerationSchema defines the schema for a toleration.
 func tolerationSchema(asDataSource bool) map[string]*schema.Schema {
+	// The operator/effect strings must match the protobuf enum names; any
+	// other value (e.g. the Kubernetes short forms "Exists"/"NoSchedule") is
+	// silently dropped by expandTolerations, leaving the toleration without an
+	// operator/effect. Validate against the enum names so a bad value fails at
+	// plan time instead of producing a misconfigured cluster.
+	validOperators := tolerationEnumNames(qcCluster.TolerationOperator_name)
+	validEffects := tolerationEnumNames(qcCluster.TolerationEffect_name)
+
+	operator := &schema.Schema{
+		Description: fmt.Sprintf("The toleration operator. Should be one of %s.", strings.Join(validOperators, ",")),
+		Type:        schema.TypeString,
+		Optional:    !asDataSource,
+		Computed:    asDataSource,
+	}
+	effect := &schema.Schema{
+		Description: fmt.Sprintf("The toleration effect. Should be one of %s.", strings.Join(validEffects, ",")),
+		Type:        schema.TypeString,
+		Optional:    !asDataSource,
+		Computed:    asDataSource,
+	}
+	// Only add ValidateFunc for resource mode (when field is Optional).
+	// Data sources are Computed-only and don't need validation.
+	if !asDataSource {
+		operator.ValidateFunc = validation.StringInSlice(validOperators, false)
+		effect.ValidateFunc = validation.StringInSlice(validEffects, false)
+	}
+
 	return map[string]*schema.Schema{
 		tolerationKeyFieldName: {
 			Type:     schema.TypeString,
 			Optional: !asDataSource,
 			Computed: asDataSource,
 		},
-		tolerationOperatorFieldName: {
-			Type:     schema.TypeString,
-			Optional: !asDataSource,
-			Computed: asDataSource,
-		},
+		tolerationOperatorFieldName: operator,
 		tolerationValueFieldName: {
 			Type:     schema.TypeString,
 			Optional: !asDataSource,
 			Computed: asDataSource,
 		},
-		tolerationEffectFieldName: {
-			Type:     schema.TypeString,
-			Optional: !asDataSource,
-			Computed: asDataSource,
-		},
+		tolerationEffectFieldName: effect,
 		tolerationSecondsFieldName: {
 			Type:     schema.TypeInt,
 			Optional: !asDataSource,
 			Computed: asDataSource,
 		},
 	}
+}
+
+// tolerationEnumNames returns the protobuf enum names accepted for a toleration
+// field, excluding the zero-value *_UNSPECIFIED sentinel (which represents an
+// unset value and is not a meaningful user input).
+func tolerationEnumNames(enumName map[int32]string) []string {
+	names := make([]string, 0, len(enumName))
+	for value, name := range enumName {
+		if value == 0 {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func topologySpreadConstraintSchema(asDataSource bool) map[string]*schema.Schema {

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -1271,11 +1271,15 @@ func expandTolerations(v []interface{}) []*qcCluster.Toleration {
 	for _, m := range v {
 		item := m.(map[string]interface{})
 		toleration := &qcCluster.Toleration{}
-		if v, ok := item[tolerationKeyFieldName]; ok {
-			toleration.Key = newPointer(v.(string))
+		// key/value are always present in the set element map (as ""), so only
+		// set the pointers when non-empty. In particular, sending an empty
+		// value pointer makes the API reject the toleration when the operator
+		// is Exists ("value must not be set when operator is Exists").
+		if v, ok := item[tolerationKeyFieldName].(string); ok && v != "" {
+			toleration.Key = newPointer(v)
 		}
-		if v, ok := item[tolerationValueFieldName]; ok {
-			toleration.Value = newPointer(v.(string))
+		if v, ok := item[tolerationValueFieldName].(string); ok && v != "" {
+			toleration.Value = newPointer(v)
 		}
 		if op, ok := item[tolerationOperatorFieldName]; ok {
 			opVal, opOk := qcCluster.TolerationOperator_value[op.(string)]

--- a/qdrant/schemas_accounts_clusters_toleration_test.go
+++ b/qdrant/schemas_accounts_clusters_toleration_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	qcCluster "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 )
 
 // TestTolerationSchemaValidatesEnumNames ensures the toleration operator/effect
@@ -35,4 +37,50 @@ func TestTolerationSchemaValidatesEnumNames(t *testing.T) {
 	ds := tolerationSchema(true)
 	assert.Nil(t, ds[tolerationOperatorFieldName].ValidateFunc)
 	assert.Nil(t, ds[tolerationEffectFieldName].ValidateFunc)
+}
+
+// TestExpandTolerationsOmitsEmptyKeyValue ensures empty key/value strings (which
+// the SDK always materializes for set elements) are not sent as empty pointers.
+// Sending an empty value pointer makes the API reject an Exists toleration with
+// "value must not be set when operator is Exists".
+func TestExpandTolerationsOmitsEmptyKeyValue(t *testing.T) {
+	in := []interface{}{
+		map[string]interface{}{
+			tolerationKeyFieldName:      "example.com/node-panther-static",
+			tolerationValueFieldName:    "", // not set by the user
+			tolerationOperatorFieldName: "TOLERATION_OPERATOR_EXISTS",
+			tolerationEffectFieldName:   "TOLERATION_EFFECT_NO_SCHEDULE",
+			tolerationSecondsFieldName:  0,
+		},
+	}
+
+	// A toleration with a non-empty value: the value must be preserved. This
+	// guards against a future change that drops all values (not just empty
+	// ones) while still passing the nil-on-empty assertion above.
+	in = append(in, map[string]interface{}{
+		tolerationKeyFieldName:      "example.com/node-panther-static",
+		tolerationValueFieldName:    "v", // set by the user
+		tolerationOperatorFieldName: "TOLERATION_OPERATOR_EQUAL",
+		tolerationEffectFieldName:   "TOLERATION_EFFECT_NO_SCHEDULE",
+		tolerationSecondsFieldName:  0,
+	})
+
+	out := expandTolerations(in)
+	require.Len(t, out, 2)
+
+	tol := out[0]
+	assert.Nil(t, tol.Value, "empty value must not be sent (nil pointer), else API rejects Exists tolerations")
+	require.NotNil(t, tol.Key)
+	assert.Equal(t, "example.com/node-panther-static", tol.GetKey())
+	require.NotNil(t, tol.Operator)
+	assert.Equal(t, qcCluster.TolerationOperator_TOLERATION_OPERATOR_EXISTS, tol.GetOperator())
+	require.NotNil(t, tol.Effect)
+	assert.Equal(t, qcCluster.TolerationEffect_TOLERATION_EFFECT_NO_SCHEDULE, tol.GetEffect())
+
+	// Positive assertion: a value the user did set must survive expansion.
+	withValue := out[1]
+	require.NotNil(t, withValue.Value, "a non-empty value must be sent")
+	assert.Equal(t, "v", withValue.GetValue())
+	require.NotNil(t, withValue.Operator)
+	assert.Equal(t, qcCluster.TolerationOperator_TOLERATION_OPERATOR_EQUAL, withValue.GetOperator())
 }

--- a/qdrant/schemas_accounts_clusters_toleration_test.go
+++ b/qdrant/schemas_accounts_clusters_toleration_test.go
@@ -1,0 +1,38 @@
+package qdrant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTolerationSchemaValidatesEnumNames ensures the toleration operator/effect
+// fields accept the protobuf enum names and reject anything else (notably the
+// Kubernetes short forms like "Exists"/"NoSchedule", which expandTolerations
+// would otherwise silently drop).
+func TestTolerationSchemaValidatesEnumNames(t *testing.T) {
+	s := tolerationSchema(false)
+
+	opValidate := s[tolerationOperatorFieldName].ValidateFunc
+	effValidate := s[tolerationEffectFieldName].ValidateFunc
+	require.NotNil(t, opValidate, "operator must have a ValidateFunc in resource mode")
+	require.NotNil(t, effValidate, "effect must have a ValidateFunc in resource mode")
+
+	// Accepted: protobuf enum names.
+	_, errs := opValidate("TOLERATION_OPERATOR_EXISTS", tolerationOperatorFieldName)
+	assert.Empty(t, errs)
+	_, errs = effValidate("TOLERATION_EFFECT_NO_SCHEDULE", tolerationEffectFieldName)
+	assert.Empty(t, errs)
+
+	// Rejected: Kubernetes short forms (the bug this guards against).
+	_, errs = opValidate("Exists", tolerationOperatorFieldName)
+	assert.NotEmpty(t, errs, "k8s short form 'Exists' must be rejected")
+	_, errs = effValidate("NoSchedule", tolerationEffectFieldName)
+	assert.NotEmpty(t, errs, "k8s short form 'NoSchedule' must be rejected")
+
+	// Data-source mode is computed-only and must not validate.
+	ds := tolerationSchema(true)
+	assert.Nil(t, ds[tolerationOperatorFieldName].ValidateFunc)
+	assert.Nil(t, ds[tolerationEffectFieldName].ValidateFunc)
+}


### PR DESCRIPTION
Fixes #249.

Two bugs in `expandTolerations` / the toleration schema (`qdrant/schemas_accounts_clusters.go`) made it hard to configure node tolerations correctly: both produced a clean `plan`/`apply` but an incorrect or API-rejected toleration. Each commit fixes one and adds a unit test.

## Commit 1 — validate toleration operator/effect enum names (`18e1b46`)

`expandTolerations` maps the `operator`/`effect` strings onto the protobuf enum value maps and silently ignores values that are not found. Supplying the Kubernetes short forms (`"Exists"` / `"NoSchedule"`) instead of the proto enum names (`TOLERATION_OPERATOR_EXISTS` / `TOLERATION_EFFECT_NO_SCHEDULE`) therefore produced a successful plan but a cluster whose pods had the operator/effect unset (operator defaulting to `Equal`, no effect).

Adds a `ValidateFunc` (`StringInSlice` of the enum names, excluding the `*_UNSPECIFIED` sentinel) to the operator and effect fields in resource mode, mirroring the existing storage-tier validation, so an invalid value fails at plan time.

## Commit 2 — do not send empty toleration key/value pointers (`e2c9409`)

For a `TypeSet` element the SDK materializes every schema field, so an unset `key`/`value` is read as `""` with `ok=true`. `expandTolerations` then set `Key`/`Value` to a pointer to an empty string, i.e. "value is set to empty". The API rejects this for `Exists` tolerations with:

```
value must not be set when operator is Exists [toleration.value_for_exists]
```

Only sets the `Key`/`Value` pointers when the string is non-empty, matching the existing guards on operator/effect/toleration_seconds.

## Testing

Adds `qdrant/schemas_accounts_clusters_toleration_test.go` covering both fixes:
- `TestTolerationSchemaValidatesEnumNames` — enum names accepted, k8s short forms rejected.
- `TestExpandTolerationsOmitsEmptyKeyValue` — empty value is sent as a nil pointer, not an empty-string pointer.
