### PR TITLE
Add hybrid storage-class fields to the cluster resource 

### DIFF
--- a/docs/data-sources/accounts_cluster.md
+++ b/docs/data-sources/accounts_cluster.md
@@ -107,7 +107,10 @@ Read-Only:
 
 Read-Only:
 
+- `database_storage_class` (String)
+- `snapshot_storage_class` (String)
 - `storage_tier_type` (String)
+- `volume_snapshot_class` (String)
 
 
 <a id="nestedobjatt--configuration--database_configuration"></a>

--- a/docs/data-sources/accounts_clusters.md
+++ b/docs/data-sources/accounts_clusters.md
@@ -110,7 +110,10 @@ Read-Only:
 
 Read-Only:
 
+- `database_storage_class` (String)
+- `snapshot_storage_class` (String)
 - `storage_tier_type` (String)
+- `volume_snapshot_class` (String)
 
 
 <a id="nestedobjatt--clusters--configuration--database_configuration"></a>

--- a/docs/resources/accounts_cluster.md
+++ b/docs/resources/accounts_cluster.md
@@ -185,7 +185,10 @@ Required:
 
 Optional:
 
+- `database_storage_class` (String) The storage class to use for the database storage, if different from the environment default. Hybrid cloud clusters only.
+- `snapshot_storage_class` (String) The storage class to use for the snapshot storage, if different from the environment default. Hybrid cloud clusters only.
 - `storage_tier_type` (String) The storage performance tier for the cluster. Should be one of STORAGE_TIER_TYPE_COST_OPTIMISED,STORAGE_TIER_TYPE_BALANCED,STORAGE_TIER_TYPE_PERFORMANCE.
+- `volume_snapshot_class` (String) The volume snapshot class to use for the database storage, if different from the environment default. Hybrid cloud clusters only.
 
 
 <a id="nestedblock--configuration--database_configuration"></a>

--- a/docs/resources/accounts_manual_backup.md
+++ b/docs/resources/accounts_manual_backup.md
@@ -153,7 +153,10 @@ Read-Only:
 
 Read-Only:
 
+- `database_storage_class` (String)
+- `snapshot_storage_class` (String)
 - `storage_tier_type` (String)
+- `volume_snapshot_class` (String)
 
 
 <a id="nestedobjatt--cluster_info--configuration--database_configuration"></a>

--- a/qdrant/schemas_accounts_clusters.go
+++ b/qdrant/schemas_accounts_clusters.go
@@ -81,6 +81,9 @@ const (
 	podLabelsFieldName                                 = "pod_labels"
 	clusterStorageConfigurationFieldName               = "cluster_storage_configuration"
 	clusterStorageTierTypeFieldName                    = "storage_tier_type"
+	clusterDatabaseStorageClassFieldName               = "database_storage_class"
+	clusterSnapshotStorageClassFieldName               = "snapshot_storage_class"
+	clusterVolumeSnapshotClassFieldName                = "volume_snapshot_class"
 	databaseConfigurationFieldName                     = "database_configuration"
 	dbConfigCollectionFieldName                        = "collection"
 	dbConfigStorageFieldName                           = "storage"
@@ -731,6 +734,24 @@ func clusterStorageConfigurationSchema(asDataSource bool) map[string]*schema.Sch
 	}
 	return map[string]*schema.Schema{
 		clusterStorageTierTypeFieldName: storageTierType,
+		clusterDatabaseStorageClassFieldName: {
+			Description: "The storage class to use for the database storage, if different from the environment default. Hybrid cloud clusters only.",
+			Type:        schema.TypeString,
+			Optional:    !asDataSource,
+			Computed:    true,
+		},
+		clusterSnapshotStorageClassFieldName: {
+			Description: "The storage class to use for the snapshot storage, if different from the environment default. Hybrid cloud clusters only.",
+			Type:        schema.TypeString,
+			Optional:    !asDataSource,
+			Computed:    true,
+		},
+		clusterVolumeSnapshotClassFieldName: {
+			Description: "The volume snapshot class to use for the database storage, if different from the environment default. Hybrid cloud clusters only.",
+			Type:        schema.TypeString,
+			Optional:    !asDataSource,
+			Computed:    true,
+		},
 	}
 }
 
@@ -1154,9 +1175,21 @@ func expandClusterStorageConfiguration(v []interface{}) *qcCluster.ClusterStorag
 			config.StorageTierType = commonv1.StorageTierType(stt)
 		}
 	}
+	// The backend clears volume_snapshot_class when it is omitted from an update,
+	// so these must always be echoed back when present in state (they are Computed).
+	if val, ok := item[clusterDatabaseStorageClassFieldName]; ok && val.(string) != "" {
+		config.DatabaseStorageClass = newPointer(val.(string))
+	}
+	if val, ok := item[clusterSnapshotStorageClassFieldName]; ok && val.(string) != "" {
+		config.SnapshotStorageClass = newPointer(val.(string))
+	}
+	if val, ok := item[clusterVolumeSnapshotClassFieldName]; ok && val.(string) != "" {
+		config.VolumeSnapshotClass = newPointer(val.(string))
+	}
 
 	// If no fields were set (or only UNSPECIFIED values), return nil
-	if config.StorageTierType == commonv1.StorageTierType_STORAGE_TIER_TYPE_UNSPECIFIED {
+	if config.StorageTierType == commonv1.StorageTierType_STORAGE_TIER_TYPE_UNSPECIFIED &&
+		config.DatabaseStorageClass == nil && config.SnapshotStorageClass == nil && config.VolumeSnapshotClass == nil {
 		return nil
 	}
 
@@ -1461,6 +1494,15 @@ func flattenClusterStorageConfiguration(storageConfig *qcCluster.ClusterStorageC
 	// Only set storage_tier_type when it's not UNSPECIFIED to avoid perpetual diffs
 	if storageTierType := storageConfig.GetStorageTierType(); storageTierType != commonv1.StorageTierType_STORAGE_TIER_TYPE_UNSPECIFIED {
 		m[clusterStorageTierTypeFieldName] = storageTierType.String()
+	}
+	if v := storageConfig.GetDatabaseStorageClass(); v != "" {
+		m[clusterDatabaseStorageClassFieldName] = v
+	}
+	if v := storageConfig.GetSnapshotStorageClass(); v != "" {
+		m[clusterSnapshotStorageClassFieldName] = v
+	}
+	if v := storageConfig.GetVolumeSnapshotClass(); v != "" {
+		m[clusterVolumeSnapshotClassFieldName] = v
 	}
 
 	// If no fields were set (all UNSPECIFIED or nil), return nil

--- a/qdrant/schemas_accounts_clusters_storage_test.go
+++ b/qdrant/schemas_accounts_clusters_storage_test.go
@@ -1,0 +1,154 @@
+package qdrant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	qcCluster "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
+)
+
+func TestExpandClusterStorageConfigurationStorageClasses(t *testing.T) {
+	config := expandClusterStorageConfiguration([]interface{}{
+		map[string]interface{}{
+			clusterStorageTierTypeFieldName:      "STORAGE_TIER_TYPE_BALANCED",
+			clusterDatabaseStorageClassFieldName: "premium-perf1-stackit",
+			clusterSnapshotStorageClassFieldName: "premium-perf1-stackit",
+			clusterVolumeSnapshotClassFieldName:  "csi-snapclass",
+		},
+	})
+	require.NotNil(t, config)
+	assert.Equal(t, commonv1.StorageTierType_STORAGE_TIER_TYPE_BALANCED, config.GetStorageTierType())
+	assert.Equal(t, "premium-perf1-stackit", config.GetDatabaseStorageClass())
+	assert.Equal(t, "premium-perf1-stackit", config.GetSnapshotStorageClass())
+	assert.Equal(t, "csi-snapclass", config.GetVolumeSnapshotClass())
+}
+
+func TestExpandClusterStorageConfigurationClassesWithoutTier(t *testing.T) {
+	// Storage classes alone must produce a non-nil configuration, otherwise the
+	// backend clears volume_snapshot_class when the message is omitted.
+	config := expandClusterStorageConfiguration([]interface{}{
+		map[string]interface{}{
+			clusterVolumeSnapshotClassFieldName: "csi-snapclass",
+		},
+	})
+	require.NotNil(t, config)
+	assert.Nil(t, config.DatabaseStorageClass)
+	assert.Nil(t, config.SnapshotStorageClass)
+	assert.Equal(t, "csi-snapclass", config.GetVolumeSnapshotClass())
+}
+
+func TestExpandClusterStorageConfigurationEmptyReturnsNil(t *testing.T) {
+	config := expandClusterStorageConfiguration([]interface{}{
+		map[string]interface{}{
+			clusterStorageTierTypeFieldName:      "",
+			clusterDatabaseStorageClassFieldName: "",
+			clusterSnapshotStorageClassFieldName: "",
+			clusterVolumeSnapshotClassFieldName:  "",
+		},
+	})
+	assert.Nil(t, config)
+}
+
+func TestFlattenClusterStorageConfigurationStorageClasses(t *testing.T) {
+	flattened := flattenClusterStorageConfiguration(&qcCluster.ClusterStorageConfiguration{
+		StorageTierType:      commonv1.StorageTierType_STORAGE_TIER_TYPE_COST_OPTIMISED,
+		DatabaseStorageClass: newPointer("premium-perf1-stackit"),
+		SnapshotStorageClass: newPointer("premium-perf1-stackit"),
+		VolumeSnapshotClass:  newPointer("csi-snapclass"),
+	})
+	expected := []interface{}{
+		map[string]interface{}{
+			clusterStorageTierTypeFieldName:      "STORAGE_TIER_TYPE_COST_OPTIMISED",
+			clusterDatabaseStorageClassFieldName: "premium-perf1-stackit",
+			clusterSnapshotStorageClassFieldName: "premium-perf1-stackit",
+			clusterVolumeSnapshotClassFieldName:  "csi-snapclass",
+		},
+	}
+	assert.Equal(t, expected, flattened)
+}
+
+// TestClusterVolumeSnapshotClassSurvivesUpdate reproduces the UI-vs-Terraform
+// wipe: volume_snapshot_class was set outside Terraform (UI) and refreshed into
+// state, while the Terraform config does not manage it. The backend clears
+// volume_snapshot_class when an update omits it, so the diff engine must
+// preserve the state value and expandCluster must echo it in the request.
+func TestClusterVolumeSnapshotClassSurvivesUpdate(t *testing.T) {
+	r := resourceAccountsCluster()
+
+	state := &terraform.InstanceState{
+		ID: "cluster-1",
+		Attributes: map[string]string{
+			"id":                                   "cluster-1",
+			"account_id":                           "acc-1",
+			"name":                                 "test-shared-qdrant",
+			"cloud_provider":                       "private",
+			"cloud_region":                         "private",
+			"configuration.#":                      "1",
+			"configuration.0.number_of_nodes":      "3",
+			"configuration.0.node_configuration.#": "1",
+			"configuration.0.node_configuration.0.package_id":                        "pkg-1",
+			"configuration.0.cluster_storage_configuration.#":                        "1",
+			"configuration.0.cluster_storage_configuration.0.storage_tier_type":      "STORAGE_TIER_TYPE_COST_OPTIMISED",
+			"configuration.0.cluster_storage_configuration.0.database_storage_class": "premium-perf1-stackit",
+			"configuration.0.cluster_storage_configuration.0.snapshot_storage_class": "premium-perf1-stackit",
+			"configuration.0.cluster_storage_configuration.0.volume_snapshot_class":  "csi-snapclass",
+		},
+	}
+
+	for name, rawConfig := range map[string]map[string]interface{}{
+		// The customer's shape: block present, storage classes not managed.
+		"block present without classes": {
+			"name":           "test-shared-qdrant",
+			"cloud_provider": "private",
+			"cloud_region":   "private",
+			"configuration": []interface{}{
+				map[string]interface{}{
+					"number_of_nodes": 3,
+					"node_configuration": []interface{}{
+						map[string]interface{}{"package_id": "pkg-1"},
+					},
+					"cluster_storage_configuration": []interface{}{
+						map[string]interface{}{"storage_tier_type": "STORAGE_TIER_TYPE_COST_OPTIMISED"},
+					},
+				},
+			},
+		},
+		// The whole storage block omitted from the Terraform config.
+		"storage block omitted": {
+			"name":           "test-shared-qdrant",
+			"cloud_provider": "private",
+			"cloud_region":   "private",
+			"configuration": []interface{}{
+				map[string]interface{}{
+					"number_of_nodes": 3,
+					"node_configuration": []interface{}{
+						map[string]interface{}{"package_id": "pkg-1"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			diff, err := r.Diff(context.Background(), state, terraform.NewResourceConfigRaw(rawConfig), nil)
+			require.NoError(t, err)
+
+			data, err := schema.InternalMap(r.SchemaMap()).Data(state, diff)
+			require.NoError(t, err)
+
+			cluster, _, err := expandCluster(data, "acc-1")
+			require.NoError(t, err)
+
+			storageConfig := cluster.GetConfiguration().GetClusterStorageConfiguration()
+			require.NotNil(t, storageConfig)
+			assert.Equal(t, "csi-snapclass", storageConfig.GetVolumeSnapshotClass())
+			assert.Equal(t, "premium-perf1-stackit", storageConfig.GetDatabaseStorageClass())
+			assert.Equal(t, "premium-perf1-stackit", storageConfig.GetSnapshotStorageClass())
+		})
+	}
+}


### PR DESCRIPTION
Add database_storage_class, snapshot_storage_class, and volume_snapshot_class to the cluster_storage_configuration block in clusters.
- Schema: Optional + Computed on the resource, Read-olny on the data sources — a value present in refreshed state is preserved and returned on the next update instead of dropped.
- expandClusterStorageConfiguration: sends the three fields when set. 
- flattenClusterStorageConfiguration: mirrors the backend values into state.

CRC-2067